### PR TITLE
Fix build and database regressions

### DIFF
--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/dennisonbertram/agentic-hosting/internal/databases"
 	"github.com/dennisonbertram/agentic-hosting/internal/middleware"
+	"github.com/go-chi/chi/v5"
 )
 
 // requireDBManager is a guard that returns 503 if dbManager is nil.
@@ -127,7 +127,7 @@ func isUserError(err error) bool {
 		return true
 	case msg == "name is required (max 128 chars)":
 		return true
-	case msg == "database quota exceeded (max 3)":
+	case len(msg) >= 23 && msg[:23] == "database quota exceeded":
 		return true
 	}
 	return false

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,21 +1,22 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
-	chimw "github.com/go-chi/chi/v5/middleware"
+	"github.com/dennisonbertram/agentic-hosting/internal/builds"
+	"github.com/dennisonbertram/agentic-hosting/internal/databases"
 	"github.com/dennisonbertram/agentic-hosting/internal/db"
 	"github.com/dennisonbertram/agentic-hosting/internal/docker"
 	"github.com/dennisonbertram/agentic-hosting/internal/httpx"
 	"github.com/dennisonbertram/agentic-hosting/internal/middleware"
-	"github.com/dennisonbertram/agentic-hosting/internal/builds"
-	"github.com/dennisonbertram/agentic-hosting/internal/databases"
 	"github.com/dennisonbertram/agentic-hosting/internal/services"
+	"github.com/go-chi/chi/v5"
+	chimw "github.com/go-chi/chi/v5/middleware"
 )
 
 type ServerConfig struct {
@@ -26,21 +27,32 @@ type ServerConfig struct {
 	OpenRegistration bool
 	Docker           docker.Client
 	BuildManager     *builds.Manager
-	DatabaseManager  *databases.Manager
+	DatabaseManager  databaseManager
+}
+
+type databaseManager interface {
+	Create(ctx context.Context, tenantID string, req databases.CreateRequest) (*databases.Database, error)
+	List(ctx context.Context, tenantID string) ([]*databases.Database, error)
+	Get(ctx context.Context, tenantID, dbID string) (*databases.Database, error)
+	GetConnectionString(ctx context.Context, tenantID, dbID string) (string, error)
+	Delete(ctx context.Context, tenantID, dbID string) error
 }
 
 type Server struct {
-	store            *db.Store
-	masterKey        []byte
-	devMode          bool
-	bootstrapToken   string
-	openRegistration bool
-	router           chi.Router
-	authMW           func(http.Handler) http.Handler
-	authInvalidator  *middleware.AuthCacheInvalidator
-	svcManager       *services.Manager
-	buildManager     *builds.Manager
-	dbManager        *databases.Manager
+	store             *db.Store
+	masterKey         []byte
+	devMode           bool
+	bootstrapToken    string
+	openRegistration  bool
+	router            chi.Router
+	authMW            func(http.Handler) http.Handler
+	authInvalidator   *middleware.AuthCacheInvalidator
+	svcManager        *services.Manager
+	buildManager      *builds.Manager
+	dbManager         databaseManager
+	authRateLimiter   *middleware.RateLimiter
+	globalRateLimiter *middleware.GlobalRateLimiter
+	idempotencyStore  *middleware.IdempotencyStore
 }
 
 func NewServer(cfg ServerConfig) *Server {
@@ -50,6 +62,9 @@ func NewServer(cfg ServerConfig) *Server {
 	// Initialize auth middleware and cache invalidator early so they are
 	// guaranteed non-nil before any request can arrive.
 	authMW, authInvalidator := middleware.Auth(cfg.Store.StateDB, cfg.MasterKey)
+	rl := middleware.NewRateLimiter(100, 200)
+	globalRL := middleware.NewGlobalRateLimiter(500, 1000)
+	idem := middleware.NewIdempotencyStore()
 
 	var svcMgr *services.Manager
 	if cfg.Docker != nil {
@@ -57,16 +72,19 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 
 	s := &Server{
-		store:            cfg.Store,
-		masterKey:        cfg.MasterKey,
-		devMode:          cfg.DevMode,
-		bootstrapToken:   cfg.BootstrapToken,
-		openRegistration: cfg.OpenRegistration,
-		authInvalidator:  authInvalidator,
-		authMW:           authMW,
-		svcManager:       svcMgr,
-		buildManager:     cfg.BuildManager,
-		dbManager:        cfg.DatabaseManager,
+		store:             cfg.Store,
+		masterKey:         cfg.MasterKey,
+		devMode:           cfg.DevMode,
+		bootstrapToken:    cfg.BootstrapToken,
+		openRegistration:  cfg.OpenRegistration,
+		authInvalidator:   authInvalidator,
+		authMW:            authMW,
+		svcManager:        svcMgr,
+		buildManager:      cfg.BuildManager,
+		dbManager:         cfg.DatabaseManager,
+		authRateLimiter:   rl,
+		globalRateLimiter: globalRL,
+		idempotencyStore:  idem,
 	}
 	s.setupRoutes()
 	return s
@@ -103,14 +121,9 @@ func (s *Server) setupRoutes() {
 	// Authenticated routes
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMW)
-		// Per-tenant rate limiter
-		rl := middleware.NewRateLimiter(100, 200)
-		r.Use(rl.Middleware)
-		// Global aggregate rate limiter across all tenants (prevents multi-tenant abuse)
-		globalRL := middleware.NewGlobalRateLimiter(500, 1000)
-		r.Use(globalRL.Middleware)
-		idem := middleware.NewIdempotencyStore()
-		r.Use(idem.Middleware)
+		r.Use(s.authRateLimiter.Middleware)
+		r.Use(s.globalRateLimiter.Middleware)
+		r.Use(s.idempotencyStore.Middleware)
 
 		r.Get("/v1/system/health/detailed", s.handleHealthDetailed)
 
@@ -152,6 +165,9 @@ func (s *Server) setupRoutes() {
 	// Long-running endpoints — auth required but no 30s timeout
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMW)
+		r.Use(s.authRateLimiter.Middleware)
+		r.Use(s.globalRateLimiter.Middleware)
+		r.Use(s.idempotencyStore.Middleware)
 		r.Get("/v1/services/{serviceID}/builds/{buildID}/logs", s.handleBuildLogs)
 		r.Post("/v1/databases", s.handleDatabaseCreate)
 	})
@@ -162,7 +178,6 @@ func (s *Server) setupRoutes() {
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.router.ServeHTTP(w, r)
 }
-
 
 // writeError delegates to httpx.WriteError for consistent JSON error responses.
 // All handlers in the api package should use this.
@@ -239,8 +254,6 @@ func requireHTTPS(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
-
-
 
 // normalizeIP extracts a validated IP string from a value that may be
 // "ip", "ip:port", or "[ip]:port". Returns "" if no valid IP is found.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dennisonbertram/agentic-hosting/internal/crypto"
+	"github.com/dennisonbertram/agentic-hosting/internal/databases"
+	"github.com/dennisonbertram/agentic-hosting/internal/db"
+	"github.com/dennisonbertram/agentic-hosting/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDatabaseManager struct {
+	createCalls int
+}
+
+func (f *fakeDatabaseManager) Create(ctx context.Context, tenantID string, req databases.CreateRequest) (*databases.Database, error) {
+	f.createCalls++
+	return &databases.Database{
+		ID:       "db-1",
+		TenantID: tenantID,
+		Name:     req.Name,
+		Type:     req.Type,
+		Status:   "ready",
+	}, nil
+}
+
+func (f *fakeDatabaseManager) List(ctx context.Context, tenantID string) ([]*databases.Database, error) {
+	return nil, nil
+}
+
+func (f *fakeDatabaseManager) Get(ctx context.Context, tenantID, dbID string) (*databases.Database, error) {
+	return nil, nil
+}
+
+func (f *fakeDatabaseManager) GetConnectionString(ctx context.Context, tenantID, dbID string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeDatabaseManager) Delete(ctx context.Context, tenantID, dbID string) error {
+	return nil
+}
+
+func TestDatabaseCreate_UsesIdempotencyMiddleware(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+	token := seedAuthenticatedTenant(t, stateDB, masterKey)
+
+	dbMgr := &fakeDatabaseManager{}
+	srv := NewServer(ServerConfig{
+		Store:           &db.Store{StateDB: stateDB},
+		MasterKey:       masterKey,
+		DevMode:         true,
+		DatabaseManager: dbMgr,
+	})
+
+	body := []byte(`{"name":"main-db","type":"postgres"}`)
+	first := httptest.NewRecorder()
+	firstReq := httptest.NewRequest(http.MethodPost, "/v1/databases", bytes.NewReader(body))
+	firstReq.Header.Set("Authorization", "Bearer "+token)
+	firstReq.Header.Set("Content-Type", "application/json")
+	firstReq.Header.Set("Idempotency-Key", "db-create-1")
+	srv.ServeHTTP(first, firstReq)
+
+	second := httptest.NewRecorder()
+	secondReq := httptest.NewRequest(http.MethodPost, "/v1/databases", bytes.NewReader(body))
+	secondReq.Header.Set("Authorization", "Bearer "+token)
+	secondReq.Header.Set("Content-Type", "application/json")
+	secondReq.Header.Set("Idempotency-Key", "db-create-1")
+	srv.ServeHTTP(second, secondReq)
+
+	require.Equal(t, http.StatusCreated, first.Code)
+	require.Equal(t, http.StatusCreated, second.Code)
+	assert.Equal(t, 1, dbMgr.createCalls, "database creation should be replayed, not executed twice")
+	assert.Equal(t, "true", second.Header().Get("Idempotency-Replayed"))
+	assert.JSONEq(t, first.Body.String(), second.Body.String())
+}
+
+func TestIsUserError_AcceptsDynamicDatabaseQuotaMessages(t *testing.T) {
+	assert.True(t, isUserError(errString("database quota exceeded (max 1)")))
+	assert.False(t, isUserError(errString("unexpected failure")))
+}
+
+func seedAuthenticatedTenant(t *testing.T, stateDB *sql.DB, masterKey []byte) string {
+	t.Helper()
+	_, err := stateDB.Exec(
+		`INSERT INTO tenants (id, name, email, status, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, 1)`,
+		"tenant-1", "Tenant", "tenant@example.com",
+	)
+	require.NoError(t, err)
+	_, err = stateDB.Exec(`INSERT INTO tenant_quotas (tenant_id) VALUES (?)`, "tenant-1")
+	require.NoError(t, err)
+
+	secret, keyID, err := crypto.GenerateAPIKeyWithID()
+	require.NoError(t, err)
+	keyHash := crypto.HashAPIKey(secret, masterKey)
+	_, err = stateDB.Exec(
+		`INSERT INTO api_keys (id, tenant_id, name, key_prefix, key_hash, created_at) VALUES (?, ?, 'default', ?, ?, 1)`,
+		keyID, "tenant-1", keyID[:8], keyHash,
+	)
+	require.NoError(t, err)
+
+	return keyID + "." + secret
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/internal/builds/builds.go
+++ b/internal/builds/builds.go
@@ -48,19 +48,24 @@ type StartBuildRequest struct {
 // DeployFunc is called when a build succeeds to deploy the resulting image.
 type DeployFunc func(ctx context.Context, tenantID, serviceID, imageTag string) error
 
+type buildExecutor interface {
+	Build(ctx context.Context, req builder.BuildRequest, logCb func(string)) error
+	CancelBuild(buildID string) error
+}
+
 // Manager coordinates build lifecycle.
 type Manager struct {
-	db       *sql.DB
-	builder  *builder.Builder
-	deployFn DeployFunc
-	logMu    sync.Mutex
+	db         *sql.DB
+	builder    buildExecutor
+	deployFn   DeployFunc
+	logMu      sync.Mutex
 	buildQueue chan struct{}            // bounded queue for build goroutines
 	logSubs    map[string][]chan string // buildID -> subscribers
-	logSizes   map[string]int          // buildID -> current log size in bytes
+	logSizes   map[string]int           // buildID -> current log size in bytes
 }
 
 // NewManager creates a build manager.
-func NewManager(db *sql.DB, b *builder.Builder, deployFn DeployFunc) *Manager {
+func NewManager(db *sql.DB, b buildExecutor, deployFn DeployFunc) *Manager {
 	m := &Manager{
 		db:         db,
 		builder:    b,
@@ -259,24 +264,33 @@ func (m *Manager) runBuild(buildID, tenantID, serviceID string, req builder.Buil
 		return
 	}
 
+	// Deploy the built image
+	logCb("[ah] Build complete")
+	if m.deployFn != nil {
+		logCb("[ah] Deploying built image...")
+		deployCtx, deployCancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		if deployErr := m.deployFn(deployCtx, tenantID, serviceID, req.ImageTag); deployErr != nil {
+			log.Printf("build %s deploy failed: %v", buildID, deployErr)
+			logCb("[ah] Deploy failed: " + deployErr.Error())
+			if _, dbErr := m.db.ExecContext(finalCtx,
+				`UPDATE builds SET status = 'failed', finished_at = ? WHERE id = ? AND status = 'running'`,
+				finishedAt, buildID,
+			); dbErr != nil {
+				log.Printf("builds: failed to mark build %s as failed after deploy error: %v", buildID, dbErr)
+			}
+			deployCancel()
+			m.closeLogSubs(buildID)
+			return
+		} else {
+			logCb("[ah] Deploy succeeded")
+		}
+		deployCancel()
+	}
 	if _, dbErr := m.db.ExecContext(finalCtx,
 		`UPDATE builds SET status = 'succeeded', finished_at = ? WHERE id = ? AND status = 'running'`,
 		finishedAt, buildID,
 	); dbErr != nil {
 		log.Printf("builds: failed to mark build %s as succeeded: %v", buildID, dbErr)
-	}
-
-	// Deploy the built image
-	logCb("[ah] Deploying built image...")
-	if m.deployFn != nil {
-		deployCtx, deployCancel := context.WithTimeout(context.Background(), 10*time.Minute)
-		if deployErr := m.deployFn(deployCtx, tenantID, serviceID, req.ImageTag); deployErr != nil {
-			log.Printf("build %s succeeded but deploy failed: %v", buildID, deployErr)
-			logCb("[ah] Deploy failed: " + deployErr.Error())
-		} else {
-			logCb("[ah] Deploy succeeded")
-		}
-		deployCancel()
 	}
 	m.closeLogSubs(buildID)
 }

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -1,0 +1,127 @@
+package builds
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dennisonbertram/agentic-hosting/internal/builder"
+	"github.com/dennisonbertram/agentic-hosting/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubBuilder struct {
+	buildFn  func(ctx context.Context, req builder.BuildRequest, logCb func(string)) error
+	cancelFn func(buildID string) error
+}
+
+func (s *stubBuilder) Build(ctx context.Context, req builder.BuildRequest, logCb func(string)) error {
+	if s.buildFn != nil {
+		return s.buildFn(ctx, req, logCb)
+	}
+	return nil
+}
+
+func (s *stubBuilder) CancelBuild(buildID string) error {
+	if s.cancelFn != nil {
+		return s.cancelFn(buildID)
+	}
+	return nil
+}
+
+func TestStartBuild_KeepsBuildRunningUntilDeployCompletes(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	seedBuildTestData(t, stateDB)
+
+	deployStarted := make(chan struct{})
+	releaseDeploy := make(chan struct{})
+	mgr := NewManager(stateDB, &stubBuilder{}, func(ctx context.Context, tenantID, serviceID, imageTag string) error {
+		close(deployStarted)
+		<-releaseDeploy
+		return nil
+	})
+
+	build, err := mgr.StartBuild(context.Background(), "tenant-1", "svc-1", StartBuildRequest{
+		SourceType: "git",
+		SourceURL:  "https://github.com/example/repo.git",
+		SourceRef:  "main",
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-deployStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for deploy to start")
+	}
+
+	current := getBuildStatus(t, stateDB, build.ID)
+	assert.Equal(t, "running", current, "build should remain running until deploy finishes")
+
+	close(releaseDeploy)
+	waitForBuildStatus(t, stateDB, build.ID, "succeeded")
+}
+
+func TestStartBuild_MarksFailedWhenDeployFails(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	seedBuildTestData(t, stateDB)
+
+	mgr := NewManager(stateDB, &stubBuilder{}, func(ctx context.Context, tenantID, serviceID, imageTag string) error {
+		return errors.New("deploy boom")
+	})
+
+	build, err := mgr.StartBuild(context.Background(), "tenant-1", "svc-1", StartBuildRequest{
+		SourceType: "git",
+		SourceURL:  "https://github.com/example/repo.git",
+		SourceRef:  "main",
+	})
+	require.NoError(t, err)
+
+	waitForBuildStatus(t, stateDB, build.ID, "failed")
+
+	logs, err := mgr.GetBuildLogs(context.Background(), "tenant-1", build.ID)
+	require.NoError(t, err)
+	assert.Contains(t, logs, "Deploy failed: deploy boom")
+}
+
+func seedBuildTestData(t *testing.T, stateDB *sql.DB) {
+	t.Helper()
+	if _, err := stateDB.Exec(
+		`INSERT INTO tenants (id, name, email, status, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, 1)`,
+		"tenant-1", "Tenant", "tenant@example.com",
+	); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if _, err := stateDB.Exec(`INSERT INTO tenant_quotas (tenant_id) VALUES (?)`, "tenant-1"); err != nil {
+		t.Fatalf("insert quota: %v", err)
+	}
+	if _, err := stateDB.Exec(
+		`INSERT INTO services (id, tenant_id, name, status, image, port, created_at, updated_at) VALUES (?, ?, ?, 'created', ?, 8080, 1, 1)`,
+		"svc-1", "tenant-1", "Service", "nginx:latest",
+	); err != nil {
+		t.Fatalf("insert service: %v", err)
+	}
+}
+
+func getBuildStatus(t *testing.T, stateDB *sql.DB, buildID string) string {
+	t.Helper()
+	var status string
+	if err := stateDB.QueryRow(`SELECT status FROM builds WHERE id = ?`, buildID).Scan(&status); err != nil {
+		t.Fatalf("query build status: %v", err)
+	}
+	return status
+}
+
+func waitForBuildStatus(t *testing.T, stateDB *sql.DB, buildID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := getBuildStatus(t, stateDB, buildID); got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for build %s to reach status %q", buildID, want)
+}

--- a/internal/databases/databases.go
+++ b/internal/databases/databases.go
@@ -124,13 +124,20 @@ func (m *Manager) Create(ctx context.Context, tenantID string, req CreateRequest
 	}
 
 	// Check quota inside an IMMEDIATE transaction to prevent concurrent creates
-	// from both seeing count < 3
+	// from both seeing count below the tenant limit.
 	tx, err := m.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
 	// Force write lock with a dummy write (SQLite IMMEDIATE)
 	_, _ = tx.ExecContext(ctx, `UPDATE databases SET updated_at = updated_at WHERE id = 'lock'`)
+	var maxDatabases int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT max_databases FROM tenant_quotas WHERE tenant_id = ?`, tenantID,
+	).Scan(&maxDatabases); err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("check quota: %w", err)
+	}
 	var count int
 	if err := tx.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM databases WHERE tenant_id = ? AND status != 'failed'`, tenantID,
@@ -138,11 +145,13 @@ func (m *Manager) Create(ctx context.Context, tenantID string, req CreateRequest
 		tx.Rollback()
 		return nil, fmt.Errorf("check quota: %w", err)
 	}
-	if count >= 3 {
+	if count >= maxDatabases {
 		tx.Rollback()
-		return nil, fmt.Errorf("database quota exceeded (max 3)")
+		return nil, fmt.Errorf("database quota exceeded (max %d)", maxDatabases)
 	}
-	tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit quota check: %w", err)
+	}
 
 	// Generate password
 	password, err := randomHex(32)

--- a/internal/databases/databases_test.go
+++ b/internal/databases/databases_test.go
@@ -1,0 +1,60 @@
+package databases
+
+import (
+	"context"
+	"database/sql"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/dennisonbertram/agentic-hosting/internal/docker"
+	"github.com/dennisonbertram/agentic-hosting/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreate_UsesTenantMaxDatabasesQuota(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	seedDatabaseTestData(t, stateDB, 1)
+
+	var listeners []net.Listener
+	t.Cleanup(func() {
+		for _, ln := range listeners {
+			_ = ln.Close()
+		}
+	})
+
+	dockerClient := &testutil.MockDockerClient{
+		RunDatabaseFn: func(ctx context.Context, cfg docker.RunDatabaseConfig) (string, error) {
+			ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(cfg.HostPort))
+			require.NoError(t, err)
+			listeners = append(listeners, ln)
+			return "container-" + cfg.Name, nil
+		},
+	}
+
+	mgr := NewManager(stateDB, dockerClient, []byte("0123456789abcdef0123456789abcdef"))
+
+	first, err := mgr.Create(context.Background(), "tenant-1", CreateRequest{Name: "db-1", Type: "postgres"})
+	require.NoError(t, err)
+	require.Equal(t, "ready", first.Status)
+
+	second, err := mgr.Create(context.Background(), "tenant-1", CreateRequest{Name: "db-2", Type: "postgres"})
+	require.Error(t, err)
+	assert.Nil(t, second)
+	assert.EqualError(t, err, "database quota exceeded (max 1)")
+}
+
+func seedDatabaseTestData(t *testing.T, stateDB *sql.DB, maxDatabases int) {
+	t.Helper()
+	_, err := stateDB.Exec(
+		`INSERT INTO tenants (id, name, email, status, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, 1)`,
+		"tenant-1", "Tenant", "tenant@example.com",
+	)
+	require.NoError(t, err)
+	_, err = stateDB.Exec(
+		`INSERT INTO tenant_quotas (tenant_id, max_databases) VALUES (?, ?)`,
+		"tenant-1", maxDatabases,
+	)
+	require.NoError(t, err)
+}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -141,28 +141,13 @@ type ResourceLimits struct {
 //   - Cross-tenant isolation: each tenant has a separate bridge network.
 //   - Defense-in-depth: gVisor (runsc) runtime, CapDrop ALL, no-new-privileges,
 //     ReadonlyRootfs, PidsLimit, MemorySwap=Memory (no swap).
+//   - Health checks are left to the image author; ah does not inject a shell
+//     probe because many minimal images do not ship curl/wget.
 func (c *DockerClient) RunContainer(ctx context.Context, tenantID, serviceID, img string, port int, envVars map[string]string, extraLabels map[string]string, limits *ResourceLimits) (string, error) {
 	name := containerName(tenantID, serviceID)
 
-	env := make([]string, 0, len(envVars))
-	for k, v := range envVars {
-		env = append(env, k+"="+v)
-	}
-
 	if port <= 0 {
 		port = 8000
-	}
-
-	labels := map[string]string{
-		"traefik.enable": "true",
-		fmt.Sprintf("traefik.http.routers.%s.rule", serviceID):                     fmt.Sprintf("Host(`%s.localhost`)", serviceID),
-		fmt.Sprintf("traefik.http.routers.%s.entrypoints", serviceID):              "web",
-		fmt.Sprintf("traefik.http.services.%s.loadbalancer.server.port", serviceID): fmt.Sprintf("%d", port),
-		"ah.tenant":  tenantID,
-		"ah.service": serviceID,
-	}
-	for k, v := range extraLabels {
-		labels[k] = v
 	}
 
 	tenantNet := TenantNetworkName(tenantID)
@@ -201,18 +186,7 @@ func (c *DockerClient) RunContainer(ctx context.Context, tenantID, serviceID, im
 	}
 
 	resp, err := c.cli.ContainerCreate(ctx,
-		&container.Config{
-			Image:  img,
-			Env:    env,
-			Labels: labels,
-			Healthcheck: &container.HealthConfig{
-				Test:        []string{"CMD-SHELL", fmt.Sprintf("wget -qO- http://localhost:%d/ > /dev/null 2>&1 || exit 1", port)},
-				Interval:    30 * time.Second,
-				Timeout:     5 * time.Second,
-				Retries:     3,
-				StartPeriod: 60 * time.Second,
-			},
-		},
+		buildServiceContainerConfig(tenantID, serviceID, img, port, envVars, extraLabels),
 		hostCfg,
 		&network.NetworkingConfig{},
 		nil,
@@ -249,6 +223,31 @@ func (c *DockerClient) RunContainer(ctx context.Context, tenantID, serviceID, im
 }
 
 func int64Ptr(v int64) *int64 { return &v }
+
+func buildServiceContainerConfig(tenantID, serviceID, img string, port int, envVars map[string]string, extraLabels map[string]string) *container.Config {
+	env := make([]string, 0, len(envVars))
+	for k, v := range envVars {
+		env = append(env, k+"="+v)
+	}
+
+	labels := map[string]string{
+		"traefik.enable": "true",
+		fmt.Sprintf("traefik.http.routers.%s.rule", serviceID):                      fmt.Sprintf("Host(`%s.localhost`)", serviceID),
+		fmt.Sprintf("traefik.http.routers.%s.entrypoints", serviceID):               "web",
+		fmt.Sprintf("traefik.http.services.%s.loadbalancer.server.port", serviceID): fmt.Sprintf("%d", port),
+		"ah.tenant":  tenantID,
+		"ah.service": serviceID,
+	}
+	for k, v := range extraLabels {
+		labels[k] = v
+	}
+
+	return &container.Config{
+		Image:  img,
+		Env:    env,
+		Labels: labels,
+	}
+}
 
 // findTraefikContainer finds the Traefik container by image or name.
 func (c *DockerClient) findTraefikContainer(ctx context.Context) (string, error) {

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -1,0 +1,24 @@
+package docker
+
+import "testing"
+
+func TestBuildServiceContainerConfig_DoesNotInjectHealthcheck(t *testing.T) {
+	cfg := buildServiceContainerConfig(
+		"tenant-1",
+		"svc-1",
+		"nginx:latest",
+		8080,
+		map[string]string{"PORT": "8080"},
+		map[string]string{"custom": "value"},
+	)
+
+	if cfg.Healthcheck != nil {
+		t.Fatalf("expected no injected healthcheck, got %#v", cfg.Healthcheck)
+	}
+	if got := cfg.Labels["ah.tenant"]; got != "tenant-1" {
+		t.Fatalf("expected tenant label to be preserved, got %q", got)
+	}
+	if got := cfg.Labels["custom"]; got != "value" {
+		t.Fatalf("expected extra label to be preserved, got %q", got)
+	}
+}

--- a/internal/middleware/idempotency.go
+++ b/internal/middleware/idempotency.go
@@ -58,10 +58,10 @@ func (s *IdempotencyStore) cleanup() {
 
 type responseRecorder struct {
 	http.ResponseWriter
-	statusCode    int
-	wroteHeader   bool
-	body          []byte
-	overflow      bool // true if body exceeded maxIdempotencyBodyLen
+	statusCode  int
+	wroteHeader bool
+	body        []byte
+	overflow    bool // true if body exceeded maxIdempotencyBodyLen
 }
 
 func (rr *responseRecorder) WriteHeader(code int) {
@@ -147,8 +147,9 @@ func (s *IdempotencyStore) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// Never cache auth key creation responses (contain secrets)
-		if strings.HasPrefix(r.URL.Path, "/v1/auth/keys") || strings.HasPrefix(r.URL.Path, "/v1/databases") {
+		// Never cache auth key creation responses because they return a secret
+		// that should only be shown on the original creation response.
+		if strings.HasPrefix(r.URL.Path, "/v1/auth/keys") {
 			next.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
This fixes four regressions in the control plane. Database creation now uses the shared auth/rate-limit/idempotency middleware stack, idempotency no longer skips /v1/databases, and database quota enforcement now respects tenant_quotas.max_databases. Builds remain running until deploy completes and fail if deploy fails, and service container creation no longer injects a wget-based health check that breaks minimal images. Regression tests were added for database idempotency, dynamic quota enforcement, build finalization, and service container config.