### PR TITLE
fix(#54): use circuit_open_count so retry backoff escalates

### DIFF
--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -110,17 +110,20 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 
 	// 1. Check services marked "running" — if container gone or exited, mark "crashed"
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, container_id, tenant_id FROM services WHERE status = 'running' AND container_id != ''`)
+		`SELECT id, container_id, tenant_id, circuit_open_count FROM services WHERE status = 'running' AND container_id != ''`)
 	if err != nil {
 		return err
 	}
 	defer rows.Close()
 
-	type svcRecord struct{ id, containerID, tenantID string }
+	type svcRecord struct {
+		id, containerID, tenantID string
+		circuitOpenCount          int
+	}
 	var runningServices []svcRecord
 	for rows.Next() {
 		var s svcRecord
-		if err := rows.Scan(&s.id, &s.containerID, &s.tenantID); err != nil {
+		if err := rows.Scan(&s.id, &s.containerID, &s.tenantID, &s.circuitOpenCount); err != nil {
 			continue
 		}
 		runningServices = append(runningServices, s)
@@ -193,7 +196,9 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 				log.Printf("reconciler: failed to mark service %s as crashed: %v", s.id, err)
 				continue
 			}
-			// Step 2: Evaluate circuit_open based on the now-updated values
+			// Step 2: Evaluate circuit_open based on the now-updated values.
+			// circuit_open_count + 1 is the new count after this opening; use it for the backoff
+			// so the delay escalates correctly: 1st open → 30m, 2nd → 1h, 3rd+ → 4h.
 			_, err = r.db.ExecContext(ctx, `
 				UPDATE services SET
 					circuit_open = CASE
@@ -210,7 +215,7 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 						ELSE circuit_open_count
 					END
 				WHERE id = ? AND tenant_id = ?`,
-				now, now, now, time.Now().Add(circuitRetryBackoff(1)).Unix(), now, s.id, s.tenantID)
+				now, now, now, time.Now().Add(circuitRetryBackoff(s.circuitOpenCount+1)).Unix(), now, s.id, s.tenantID)
 			if err != nil {
 				log.Printf("reconciler: failed to update circuit breaker for service %s: %v", s.id, err)
 			}
@@ -263,6 +268,8 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 			log.Printf("reconciler: failed to update crash state for unhealthy service %s: %v", s.id, err)
 			continue
 		}
+		// circuit_open_count + 1 is the new count after this opening; use it for the backoff
+		// so the delay escalates correctly: 1st open → 30m, 2nd → 1h, 3rd+ → 4h.
 		_, err = r.db.ExecContext(ctx, `
 			UPDATE services SET
 				circuit_open = CASE
@@ -279,7 +286,7 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 					ELSE circuit_open_count
 				END
 			WHERE id = ? AND tenant_id = ?`,
-			now, now, now, time.Now().Add(circuitRetryBackoff(1)).Unix(), now, s.id, s.tenantID)
+			now, now, now, time.Now().Add(circuitRetryBackoff(s.circuitOpenCount+1)).Unix(), now, s.id, s.tenantID)
 		if err != nil {
 			log.Printf("reconciler: failed to update circuit breaker for unhealthy service %s: %v", s.id, err)
 		}

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -150,6 +150,63 @@ func TestReconciler_UnhealthyRestart(t *testing.T) {
 	assert.Equal(t, "crashed", status, "unhealthy service should be marked as crashed")
 }
 
+// TestReconciler_CircuitBreakerBackoffEscalation verifies that the retry delay escalates with
+// circuit_open_count: after 3 circuit opens the delay should be 4h, not 30m.
+func TestReconciler_CircuitBreakerBackoffEscalation(t *testing.T) {
+	db := testutil.NewStateDB(t)
+	ctx := context.Background()
+	now := time.Now().Unix()
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO tenants (id, name, email, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"tenant-1", "Test Tenant", "test@example.com", "active", now, now)
+	require.NoError(t, err)
+
+	// Service with crash_count=4 and circuit_open_count=2 (already opened twice before).
+	// The next crash will be the 3rd circuit open → backoff should be 4h.
+	windowStart := now - 100
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO services (id, tenant_id, name, status, container_id, crash_count, circuit_open, crash_window_start, circuit_open_count, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"svc-escalate", "tenant-1", "escalation-svc", "running", "container-esc",
+		4, 0, windowStart, 2, now, now)
+	require.NoError(t, err)
+
+	// Mock Docker: container is in the list but reports exited.
+	mock := &testutil.MockDockerClient{}
+	mock.ListContainersByLabelFn = func(ctx context.Context, label, value string) ([]string, error) {
+		if label == "ah.tenant" {
+			return []string{"container-esc"}, nil
+		}
+		return nil, nil
+	}
+	mock.InspectContainerFn = func(ctx context.Context, containerID string) (*docker.ContainerInfo, error) {
+		return &docker.ContainerInfo{Status: "exited", ExitCode: 1}, nil
+	}
+
+	before := time.Now()
+	r := reconciler.New(db, mock, time.Minute)
+	require.NoError(t, r.ReconcileOnce(ctx))
+
+	var circuitOpen, circuitOpenCount int
+	var circuitRetryAt int64
+	err = db.QueryRowContext(ctx,
+		`SELECT circuit_open, circuit_open_count, circuit_retry_at FROM services WHERE id = ?`, "svc-escalate").
+		Scan(&circuitOpen, &circuitOpenCount, &circuitRetryAt)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, circuitOpen, "circuit should be open after 5th crash")
+	assert.Equal(t, 3, circuitOpenCount, "circuit_open_count should be 3")
+
+	// circuit_retry_at must be ~4h from now, not 30m.
+	minExpected := before.Add(4 * time.Hour).Unix()
+	maxExpected := time.Now().Add(4*time.Hour + 5*time.Second).Unix()
+	assert.GreaterOrEqual(t, circuitRetryAt, minExpected,
+		"retry delay after 3rd open should be at least 4h (got %ds from now)", circuitRetryAt-now)
+	assert.LessOrEqual(t, circuitRetryAt, maxExpected,
+		"retry delay should not exceed 4h+5s")
+}
+
 // TestReconciler_StaleDeployment verifies services stuck deploying >10min are marked failed.
 func TestReconciler_StaleDeployment(t *testing.T) {
 	db := testutil.NewStateDB(t)


### PR DESCRIPTION
## Summary
- `circuitRetryBackoff(n)` returns 30m / 1h / 4h for n=1/2/3+ but both call sites hardcoded `1`, so the delay never escalated beyond 30 minutes
- Now passes `s.circuitOpenCount + 1` (the post-increment count) so services that repeatedly crash get progressively longer recovery delays
- Also fetches `circuit_open_count` from DB in the reconciler query

## Test plan
- [x] `TestReconciler_CircuitBreakerBackoffEscalation` — seeds `circuit_open_count=2`, verifies 3rd open produces ≥4h retry delay
- [x] `go test ./internal/reconciler/...` passes

Closes #54