### PR TITLE
fix(#51): protocol-level readiness for postgres and redis

### DIFF
--- a/internal/databases/databases.go
+++ b/internal/databases/databases.go
@@ -513,13 +513,17 @@ func (m *Manager) runRedis(ctx context.Context, name, volume string, port int, p
 	})
 }
 
+// waitForPostgres probes Postgres at the protocol level. It sends a minimal
+// StartupMessage (protocol 3.0) over a raw TCP connection and checks that the
+// server responds with any valid Postgres message byte (AuthenticationOK 'R',
+// AuthenticationMD5Password 'R', or ErrorResponse 'E'). Any such response
+// means the server process is initialised and accepting queries; a plain TCP
+// accept with no bytes means the container is still starting up.
 func (m *Manager) waitForPostgres(port int, password string, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	addr := "127.0.0.1:" + strconv.Itoa(port)
 	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
-		if err == nil {
-			conn.Close()
+		if postgresReady(addr) {
 			return true
 		}
 		time.Sleep(1 * time.Second)
@@ -527,18 +531,93 @@ func (m *Manager) waitForPostgres(port int, password string, timeout time.Durati
 	return false
 }
 
+// postgresReady returns true when the Postgres server at addr has completed
+// initialisation and is ready to authenticate connections.
+func postgresReady(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	// Build a StartupMessage for protocol 3.0 with user "ah" and database "ah".
+	// Wire format: int32 total_length | int32 protocol_version | key\0value\0 ... \0
+	user := "ah"
+	dbName := "ah"
+	// Parameters section: "user\0<user>\0database\0<dbname>\0\0"
+	params := "user\x00" + user + "\x00database\x00" + dbName + "\x00\x00"
+	// Total length = 4 (length field) + 4 (protocol version) + len(params)
+	totalLen := int32(4 + 4 + len(params))
+	msg := make([]byte, totalLen)
+	// Length (big-endian int32)
+	msg[0] = byte(totalLen >> 24)
+	msg[1] = byte(totalLen >> 16)
+	msg[2] = byte(totalLen >> 8)
+	msg[3] = byte(totalLen)
+	// Protocol version 3.0 = 0x00030000
+	msg[4] = 0x00
+	msg[5] = 0x03
+	msg[6] = 0x00
+	msg[7] = 0x00
+	copy(msg[8:], params)
+
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err := conn.Write(msg); err != nil {
+		return false
+	}
+
+	// Read the first byte of the server response. Any valid Postgres backend
+	// message type here confirms the server is running:
+	//   'R' = Authentication message (AuthenticationOK or auth challenge)
+	//   'E' = ErrorResponse (e.g. wrong password, unknown user — still means up)
+	//   'N' = NoticeResponse
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err != nil {
+		return false
+	}
+	b := buf[0]
+	return b == 'R' || b == 'E' || b == 'N'
+}
+
+// waitForRedis probes Redis at the protocol level. It sends a RESP PING
+// command and checks that the server responds with +PONG. A container that
+// accepts TCP but has not finished loading its data set or configuration will
+// not respond to PING yet.
 func (m *Manager) waitForRedis(port int, password string, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	addr := "127.0.0.1:" + strconv.Itoa(port)
 	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
-		if err == nil {
-			conn.Close()
+		if redisReady(addr) {
 			return true
 		}
 		time.Sleep(1 * time.Second)
 	}
 	return false
+}
+
+// redisReady returns true when the Redis server at addr responds to a PING
+// with +PONG, indicating it is fully initialised.
+func redisReady(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// RESP inline PING: *1\r\n$4\r\nPING\r\n
+	if _, err := conn.Write([]byte("*1\r\n$4\r\nPING\r\n")); err != nil {
+		return false
+	}
+
+	// Read enough bytes to check for "+PONG"
+	buf := make([]byte, 7)
+	n, err := conn.Read(buf)
+	if err != nil || n < 5 {
+		return false
+	}
+	return strings.HasPrefix(string(buf[:n]), "+PONG")
 }
 
 func generateID() (string, error) {

--- a/internal/databases/databases_test.go
+++ b/internal/databases/databases_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/dennisonbertram/agentic-hosting/internal/docker"
 	"github.com/dennisonbertram/agentic-hosting/internal/testutil"
@@ -13,22 +14,229 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// serveFakePostgres starts a TCP listener that immediately sends a
+// single-byte Postgres Authentication message ('R') to every connection,
+// simulating a fully-initialised Postgres server. It returns the bound port
+// and a cleanup function.
+func serveFakePostgres(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				// Read (and discard) the StartupMessage so the client write succeeds.
+				buf := make([]byte, 256)
+				c.Read(buf) //nolint:errcheck
+				// Send a minimal AuthenticationOK response:
+				// 'R' (1 byte message type) + int32 length (5) + int32 auth-type (0 = OK)
+				// Total: 1 + 4 + 4 = 9 bytes
+				resp := []byte{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+				c.Write(resp) //nolint:errcheck
+			}(conn)
+		}
+	}()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	return port
+}
+
+// serveFakeRedis starts a TCP listener that replies "+PONG\r\n" to every
+// incoming connection, simulating a ready Redis server.
+func serveFakeRedis(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 64)
+				c.Read(buf) //nolint:errcheck
+				c.Write([]byte("+PONG\r\n")) //nolint:errcheck
+			}(conn)
+		}
+	}()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	return port
+}
+
+// serveSilentTCP starts a TCP listener that accepts connections but never
+// sends any data, simulating a container that has bound its port but has not
+// finished initialising its database engine.
+func serveSilentTCP(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Accept but never write — hold the connection open briefly.
+			go func(c net.Conn) {
+				time.Sleep(5 * time.Second)
+				c.Close()
+			}(conn)
+		}
+	}()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	return port
+}
+
+// ---------------------------------------------------------------------------
+// Protocol-level readiness unit tests
+// ---------------------------------------------------------------------------
+
+// TestPostgresReady_SilentTCPIsNotReady verifies that a server which accepts
+// TCP connections but never sends any Postgres protocol bytes is NOT
+// considered ready. This is the core regression test for issue #51.
+func TestPostgresReady_SilentTCPIsNotReady(t *testing.T) {
+	port := serveSilentTCP(t)
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	got := postgresReady(addr)
+	assert.False(t, got, "a silent TCP listener should not be considered postgres-ready")
+}
+
+// TestPostgresReady_ProperResponseIsReady verifies that a server which sends a
+// valid Postgres authentication byte in response to a StartupMessage IS
+// considered ready.
+func TestPostgresReady_ProperResponseIsReady(t *testing.T) {
+	port := serveFakePostgres(t)
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	got := postgresReady(addr)
+	assert.True(t, got, "a fake postgres server sending 'R' should be considered ready")
+}
+
+// TestPostgresReady_ErrorResponseIsReady verifies that even an ErrorResponse
+// ('E') from Postgres — e.g. wrong password — is treated as "server is up".
+func TestPostgresReady_ErrorResponseIsReady(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 256)
+				c.Read(buf) //nolint:errcheck
+				// Send ErrorResponse header byte 'E'
+				c.Write([]byte{'E', 0, 0, 0, 5, 0}) //nolint:errcheck
+			}(conn)
+		}
+	}()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	got := postgresReady(addr)
+	assert.True(t, got, "a Postgres ErrorResponse means the server is up and should be considered ready")
+}
+
+// TestRedisReady_SilentTCPIsNotReady verifies that a server which accepts TCP
+// connections but never sends +PONG is NOT considered ready.
+func TestRedisReady_SilentTCPIsNotReady(t *testing.T) {
+	port := serveSilentTCP(t)
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	got := redisReady(addr)
+	assert.False(t, got, "a silent TCP listener should not be considered redis-ready")
+}
+
+// TestRedisReady_ProperPongIsReady verifies that a server which responds with
+// +PONG to a PING command IS considered ready.
+func TestRedisReady_ProperPongIsReady(t *testing.T) {
+	port := serveFakeRedis(t)
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	got := redisReady(addr)
+	assert.True(t, got, "a fake redis server responding +PONG should be considered ready")
+}
+
+// TestRedisReady_WrongResponseIsNotReady verifies that a server responding
+// with something other than +PONG is not considered ready.
+func TestRedisReady_WrongResponseIsNotReady(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 64)
+				c.Read(buf) //nolint:errcheck
+				// Send a LOADING error, as Redis does during RDB restore
+				c.Write([]byte("-LOADING Redis is loading\r\n")) //nolint:errcheck
+			}(conn)
+		}
+	}()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	got := redisReady(addr)
+	assert.False(t, got, "a redis server returning a non-PONG response should not be considered ready")
+}
+
+// ---------------------------------------------------------------------------
+// Manager integration tests
+// ---------------------------------------------------------------------------
+
 func TestCreate_UsesTenantMaxDatabasesQuota(t *testing.T) {
 	stateDB := testutil.NewStateDB(t)
 	seedDatabaseTestData(t, stateDB, 1)
 
-	var listeners []net.Listener
-	t.Cleanup(func() {
-		for _, ln := range listeners {
-			_ = ln.Close()
-		}
-	})
-
 	dockerClient := &testutil.MockDockerClient{
+		// RunDatabaseFn starts a fake Postgres server on the allocated port so
+		// that waitForPostgres succeeds with full protocol-level verification.
 		RunDatabaseFn: func(ctx context.Context, cfg docker.RunDatabaseConfig) (string, error) {
+			// Start a fake Postgres server on the exact port that the manager
+			// allocated and will probe.
 			ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(cfg.HostPort))
 			require.NoError(t, err)
-			listeners = append(listeners, ln)
+			t.Cleanup(func() { ln.Close() })
+
+			go func() {
+				for {
+					conn, err := ln.Accept()
+					if err != nil {
+						return
+					}
+					go func(c net.Conn) {
+						defer c.Close()
+						buf := make([]byte, 256)
+						c.Read(buf) //nolint:errcheck
+						// AuthenticationOK response
+						resp := []byte{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+						c.Write(resp) //nolint:errcheck
+					}(conn)
+				}
+			}()
+
 			return "container-" + cfg.Name, nil
 		},
 	}


### PR DESCRIPTION
## Summary
- `waitForPostgres()` and `waitForRedis()` previously accepted any TCP connection as "ready", including containers that were still initializing
- Now performs protocol-level handshakes: sends Postgres StartupMessage and checks for auth/error byte; sends Redis RESP PING and checks for +PONG
- No new dependencies — uses only stdlib `net` package

## Test plan
- [x] `TestPostgresReady_SilentTCPIsNotReady` — silent listener → false
- [x] `TestPostgresReady_ProperResponseIsReady` — auth response byte → true
- [x] `TestRedisReady_SilentTCPIsNotReady` — silent listener → false
- [x] `TestRedisReady_ProperPongIsReady` — +PONG response → true
- [x] `TestRedisReady_WrongResponseIsNotReady` — -LOADING → false
- [x] `go test ./...` passes

Closes #51