### PR TITLE
fix(#56): support SHA refs in git builds via two-phase clone

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -197,6 +197,20 @@ func sanitizeLogLine(line string) string {
 	}, line)
 }
 
+// isGitSHA returns true if ref looks like a full (40-char) or abbreviated (7+ char)
+// git commit SHA — i.e. 7 to 40 lowercase hex characters.
+func isGitSHA(ref string) bool {
+	if len(ref) < 7 || len(ref) > 40 {
+		return false
+	}
+	for _, c := range ref {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
 func (b *Builder) gitClone(ctx context.Context, req BuildRequest, buildDir string, logCb func(string)) error {
 	ref := req.SourceRef
 	if ref == "" {
@@ -208,44 +222,126 @@ func (b *Builder) gitClone(ctx context.Context, req BuildRequest, buildDir strin
 	cloneCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	// Run git clone as ah-builder user via systemd-run for isolation
 	unitName := fmt.Sprintf("ah-clone-%s.scope", req.BuildID[:16])
-	cmd := exec.CommandContext(cloneCtx,
-		"systemd-run", "--scope", "--quiet",
-		"--unit="+unitName,
-		"-p", "MemoryMax=512M",
-		"/usr/sbin/runuser", "-u", "ah-builder", "--",
-		"git", "clone", "--depth=1", "--branch", ref,
-		"--config", "http.followRedirects=false",
-		req.SourceURL, buildDir,
-	)
-	cmd.Dir = b.workDir
-	cmd.Env = []string{
-		"HOME=/tmp",
-		"PATH=/usr/local/bin:/usr/bin:/bin",
-		"GIT_TERMINAL_PROMPT=0",
-	}
 
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
+	if isGitSHA(ref) {
+		// Two-phase clone for SHA refs: git clone does not support --branch <sha>,
+		// so we do a full clone first and then checkout the specific commit.
+		logCb("[ah] Ref looks like a SHA — performing full clone then checkout")
 
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start git clone: %w", err)
-	}
-	b.trackUnit(req.BuildID, unitName)
-	defer b.untrackUnit(req.BuildID)
+		// Phase 1: full clone (no --depth, no --branch)
+		cmd := exec.CommandContext(cloneCtx,
+			"systemd-run", "--scope", "--quiet",
+			"--unit="+unitName,
+			"-p", "MemoryMax=512M",
+			"/usr/sbin/runuser", "-u", "ah-builder", "--",
+			"git", "clone",
+			"--config", "http.followRedirects=false",
+			req.SourceURL, buildDir,
+		)
+		cmd.Dir = b.workDir
+		cmd.Env = []string{
+			"HOME=/tmp",
+			"PATH=/usr/local/bin:/usr/bin:/bin",
+			"GIT_TERMINAL_PROMPT=0",
+		}
 
-	go streamLines(stdout, logCb)
-	go streamLines(stderr, logCb)
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
 
-	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("git clone failed: %w", err)
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("start git clone: %w", err)
+		}
+		b.trackUnit(req.BuildID, unitName)
+		defer b.untrackUnit(req.BuildID)
+
+		go streamLines(stdout, logCb)
+		go streamLines(stderr, logCb)
+
+		if err := cmd.Wait(); err != nil {
+			return fmt.Errorf("git clone failed: %w", err)
+		}
+
+		// Phase 2: checkout the specific commit SHA
+		checkoutUnitName := fmt.Sprintf("ah-checkout-%s.scope", req.BuildID[:16])
+		checkoutCmd := exec.CommandContext(cloneCtx,
+			"systemd-run", "--scope", "--quiet",
+			"--unit="+checkoutUnitName,
+			"-p", "MemoryMax=512M",
+			"/usr/sbin/runuser", "-u", "ah-builder", "--",
+			"git", "-C", buildDir, "checkout", ref,
+		)
+		checkoutCmd.Dir = b.workDir
+		checkoutCmd.Env = []string{
+			"HOME=/tmp",
+			"PATH=/usr/local/bin:/usr/bin:/bin",
+			"GIT_TERMINAL_PROMPT=0",
+		}
+
+		checkoutStderr, err := checkoutCmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+		checkoutStdout, err := checkoutCmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
+
+		if err := checkoutCmd.Start(); err != nil {
+			return fmt.Errorf("start git checkout: %w", err)
+		}
+
+		go streamLines(checkoutStdout, logCb)
+		go streamLines(checkoutStderr, logCb)
+
+		if err := checkoutCmd.Wait(); err != nil {
+			return fmt.Errorf("git checkout %s failed: %w", ref, err)
+		}
+	} else {
+		// Branch/tag ref: shallow clone directly to the ref (fast path).
+		cmd := exec.CommandContext(cloneCtx,
+			"systemd-run", "--scope", "--quiet",
+			"--unit="+unitName,
+			"-p", "MemoryMax=512M",
+			"/usr/sbin/runuser", "-u", "ah-builder", "--",
+			"git", "clone", "--depth=1", "--branch", ref,
+			"--config", "http.followRedirects=false",
+			req.SourceURL, buildDir,
+		)
+		cmd.Dir = b.workDir
+		cmd.Env = []string{
+			"HOME=/tmp",
+			"PATH=/usr/local/bin:/usr/bin:/bin",
+			"GIT_TERMINAL_PROMPT=0",
+		}
+
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
+
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("start git clone: %w", err)
+		}
+		b.trackUnit(req.BuildID, unitName)
+		defer b.untrackUnit(req.BuildID)
+
+		go streamLines(stdout, logCb)
+		go streamLines(stderr, logCb)
+
+		if err := cmd.Wait(); err != nil {
+			return fmt.Errorf("git clone failed: %w", err)
+		}
 	}
 
 	logCb("[ah] Clone complete")

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -1,0 +1,91 @@
+package builder
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsGitSHA(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		// Clearly branch names — must be false
+		{"main", false},
+		{"master", false},
+		{"HEAD", false},
+		{"feature/foo", false},
+		{"v1.0.0", false},
+		{"release-2024", false},
+
+		// Too short (< 7 chars) — false even if all hex
+		{"abc123", false},
+		{"", false},
+		{"a", false},
+
+		// Too long (> 40 chars) — false
+		{strings.Repeat("a", 41), false},
+
+		// Contains non-hex chars — false
+		{"abc123g", false},   // 'g' is not hex
+		{"abc123G", false},   // uppercase G, but also: uppercase letters are not valid hex lower
+		{"abcdefg1234567", false},
+		{"ABCDEF1234567", false}, // uppercase hex — our helper requires lowercase
+
+		// Valid abbreviated SHA (7 chars)
+		{"abc1234", true},
+		{"0000000", true},
+		{"deadbee", true},
+		{"1234567", true},
+
+		// Valid SHA between 7 and 40 chars
+		{"abc1234def567", true},
+		{"abcdef1234567890abcd", true},
+
+		// Valid full 40-char SHA
+		{strings.Repeat("a", 40), true},
+		{"a" + strings.Repeat("b", 38) + "c", true},
+		{"0000000000000000000000000000000000000000", true},
+		{"abcdef0123456789abcdef0123456789abcdef01", true},
+
+		// Exactly 40 chars but contains non-hex
+		{"abcdef0123456789abcdef0123456789abcdefgg", false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.ref, func(t *testing.T) {
+			got := isGitSHA(tc.ref)
+			if got != tc.want {
+				t.Errorf("isGitSHA(%q) = %v, want %v", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGitCloneArgs_BranchVsSHA verifies that the builder selects the correct
+// git strategy based on whether the ref looks like a SHA or a branch name.
+// We do this by inspecting isGitSHA directly — the integration (systemd-run)
+// is exercised in the real clone path, which requires a live server.
+func TestGitCloneArgs_BranchVsSHA(t *testing.T) {
+	// Branch refs must NOT be treated as SHAs (uses --depth=1 --branch path)
+	branchRefs := []string{"main", "master", "develop", "feature/login", "v1.2.3"}
+	for _, ref := range branchRefs {
+		if isGitSHA(ref) {
+			t.Errorf("ref %q was incorrectly detected as a SHA; should use --depth=1 --branch path", ref)
+		}
+	}
+
+	// SHA refs must be detected as SHAs (uses full clone + checkout path)
+	shaRefs := []string{
+		"abc1234",
+		"deadbeef",
+		"abcdef0123456789abcdef0123456789abcdef01",
+		"0000000000000000000000000000000000000000",
+	}
+	for _, ref := range shaRefs {
+		if !isGitSHA(ref) {
+			t.Errorf("ref %q was not detected as a SHA; should use full-clone+checkout path", ref)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `git clone --depth=1 --branch <ref>` fails for SHA refs since git cannot use a commit hash as a branch name
- Adds `isGitSHA(ref)` detection (7-40 lowercase hex chars) and a two-phase clone for SHA refs: full `git clone` then `git checkout <sha>`
- Branch/tag refs continue to use the fast shallow clone path unchanged

## Test plan
- [x] `TestIsGitSHA` — 25 table-driven cases covering branches, SHAs, invalid inputs
- [x] `TestGitCloneArgs_BranchVsSHA` — confirms routing to correct clone strategy
- [x] `go test ./internal/builder/... ./internal/builds/...` passes

Closes #56