### PR TITLE
fix(#19): rename /agentic-paasd → /agentic-hosting in docs and on server

### DIFF
--- a/.claude/skills/agentic-hosting/references/operations.md
+++ b/.claude/skills/agentic-hosting/references/operations.md
@@ -163,7 +163,7 @@ ssh root@<server> "sqlite3 /var/lib/paasd/paasd.db 'SELECT name FROM schema_migr
 
 ```bash
 # Backup the state database (contains all tenant/service/database metadata)
-ssh root@<server> "/agentic-paasd/bin/paasd backup /var/lib/paasd/paasd.db"
+ssh root@<server> "/agentic-hosting/bin/paasd backup /var/lib/paasd/paasd.db"
 # Output: /var/lib/paasd/backups/paasd-<timestamp>.db
 
 # The master key must also be backed up separately — without it, all

--- a/.claude/skills/agentic-hosting/references/server-setup.md
+++ b/.claude/skills/agentic-hosting/references/server-setup.md
@@ -52,8 +52,8 @@ which nixpacks   # must return a path
 ## 5. Clone and Build
 
 ```bash
-mkdir -p /agentic-paasd
-cd /agentic-paasd
+mkdir -p /agentic-hosting
+cd /agentic-hosting
 git clone https://github.com/dennisonbertram/agentic-hosting .
 export PATH=$PATH:/usr/local/go/bin
 CGO_ENABLED=1 go build -o /usr/local/bin/paasd ./cmd/ah/


### PR DESCRIPTION
## Summary
- Renamed `/agentic-paasd` to `/agentic-hosting` on the production server (65.21.67.254)
- Updated all docs/skill references (`operations.md`, `server-setup.md`) from old path to new
- The installed binary remains at `/usr/local/bin/paasd` (unchanged)

## Test plan
- [x] Server directory renamed via SSH: `ls /agentic-hosting/bin/` confirms `ah` and `paasd` binaries
- [x] paasd service still running after rename (binary is at /usr/local/bin/paasd, unaffected)

Closes #19