### PR TITLE
fix(#9): wipe volume data before removal on database delete

### DIFF
--- a/internal/databases/databases.go
+++ b/internal/databases/databases.go
@@ -401,6 +401,15 @@ func (m *Manager) Delete(ctx context.Context, tenantID, dbID string) error {
 		}
 	}
 
+	// Securely wipe volume data before removal to prevent future tenants from
+	// recovering data (issue #9). Best-effort: a wipe failure is logged but does
+	// not block removal, since the volume will be deleted immediately after.
+	if d.VolumeName != "" {
+		if err := m.wipeVolume(ctx, d.VolumeName); err != nil {
+			log.Printf("databases: wipe volume %s failed (continuing with removal): %v", d.VolumeName, err)
+		}
+	}
+
 	// Remove volume
 	if d.VolumeName != "" {
 		if err := m.docker.RemoveVolume(ctx, d.VolumeName); err != nil {
@@ -466,6 +475,15 @@ func (m *Manager) StopAllForTenant(ctx context.Context, tenantID string) {
 	if len(dbs) > 0 {
 		log.Printf("databases: StopAllForTenant stopped %d databases for tenant %s", len(dbs), tenantID)
 	}
+}
+
+// wipeVolume runs a short-lived container to overwrite all files in the named
+// volume with zeros, ensuring a future tenant cannot recover data after a
+// database is deleted. The wipe uses a 2-minute timeout to bound the operation.
+func (m *Manager) wipeVolume(ctx context.Context, volumeName string) error {
+	wipeCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	return m.docker.WipeVolume(wipeCtx, volumeName)
 }
 
 func (m *Manager) updateStatus(ctx context.Context, id, status string) bool {

--- a/internal/databases/databases_test.go
+++ b/internal/databases/databases_test.go
@@ -253,6 +253,64 @@ func TestCreate_UsesTenantMaxDatabasesQuota(t *testing.T) {
 	assert.ErrorContains(t, err, "database quota exceeded (max 1)")
 }
 
+// TestDelete_WipesVolumeBeforeRemoval verifies that WipeVolume is called before
+// RemoveVolume when a database is deleted, ensuring data cannot be recovered by
+// a future tenant (issue #9).
+func TestDelete_WipesVolumeBeforeRemoval(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	seedDatabaseTestData(t, stateDB, 5)
+
+	var (
+		listeners  []net.Listener
+		callOrder  []string
+		wipeVolume string
+	)
+	t.Cleanup(func() {
+		for _, ln := range listeners {
+			_ = ln.Close()
+		}
+	})
+
+	dockerClient := &testutil.MockDockerClient{
+		RunDatabaseFn: func(ctx context.Context, cfg docker.RunDatabaseConfig) (string, error) {
+			ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(cfg.HostPort))
+			require.NoError(t, err)
+			listeners = append(listeners, ln)
+			return "container-" + cfg.Name, nil
+		},
+		WipeVolumeFn: func(ctx context.Context, name string) error {
+			callOrder = append(callOrder, "wipe")
+			wipeVolume = name
+			return nil
+		},
+		RemoveVolumeFn: func(ctx context.Context, name string) error {
+			callOrder = append(callOrder, "remove")
+			return nil
+		},
+	}
+
+	mgr := NewManager(stateDB, dockerClient, []byte("0123456789abcdef0123456789abcdef"))
+
+	// Create a postgres database
+	db, err := mgr.Create(context.Background(), "tenant-1", CreateRequest{Name: "wipe-test", Type: "postgres"})
+	require.NoError(t, err)
+	require.Equal(t, "ready", db.Status)
+	expectedVolume := db.VolumeName
+
+	// Reset call order tracking to isolate delete behaviour
+	callOrder = nil
+
+	// Delete the database
+	err = mgr.Delete(context.Background(), "tenant-1", db.ID)
+	require.NoError(t, err)
+
+	// Wipe must have been called before remove, and on the correct volume
+	require.Equal(t, []string{"wipe", "remove"}, callOrder,
+		"WipeVolume must be called before RemoveVolume")
+	assert.Equal(t, expectedVolume, wipeVolume,
+		"WipeVolume must receive the database's volume name")
+}
+
 func seedDatabaseTestData(t *testing.T, stateDB *sql.DB, maxDatabases int) {
 	t.Helper()
 	_, err := stateDB.Exec(

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -40,6 +40,7 @@ type Client interface {
 	CreateVolume(ctx context.Context, name string) error
 	RemoveVolume(ctx context.Context, name string) error
 	RemoveVolumeSafe(ctx context.Context, name string) error
+	WipeVolume(ctx context.Context, name string) error
 	RunDatabase(ctx context.Context, cfg RunDatabaseConfig) (string, error)
 	StopAndRemoveByName(ctx context.Context, name string) error
 	PruneDanglingImages(ctx context.Context) (int, error)
@@ -441,6 +442,54 @@ func (c *DockerClient) RemoveVolume(ctx context.Context, name string) error {
 // be attached to a running container.
 func (c *DockerClient) RemoveVolumeSafe(ctx context.Context, name string) error {
 	return c.cli.VolumeRemove(ctx, name, false)
+}
+
+// WipeVolume overwrites all files in the named volume with zeros using a
+// short-lived busybox container. This prevents a future tenant from recovering
+// data after a database is deleted. The container is removed automatically
+// after the wipe completes (--rm equivalent via AutoRemove).
+// A best-effort operation: errors are logged but do not block volume removal.
+func (c *DockerClient) WipeVolume(ctx context.Context, name string) error {
+	containerCfg := &container.Config{
+		Image: "busybox:latest",
+		Cmd:   []string{"sh", "-c", "find /data -type f -exec sh -c 'dd if=/dev/zero of=\"$1\" bs=1M conv=notrunc 2>/dev/null; rm -f \"$1\"' _ {} \\;"},
+	}
+	hostCfg := &container.HostConfig{
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeVolume,
+				Source: name,
+				Target: "/data",
+			},
+		},
+		AutoRemove: true,
+	}
+
+	resp, err := c.cli.ContainerCreate(ctx, containerCfg, hostCfg, nil, nil, "")
+	if err != nil {
+		return fmt.Errorf("wipe volume %s: create container: %w", name, err)
+	}
+
+	if err := c.cli.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+		// Clean up the created-but-not-started container
+		_ = c.cli.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
+		return fmt.Errorf("wipe volume %s: start container: %w", name, err)
+	}
+
+	// Wait for the wipe container to finish
+	statusCh, errCh := c.cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return fmt.Errorf("wipe volume %s: wait: %w", name, err)
+		}
+	case body := <-statusCh:
+		if body.Error != nil {
+			return fmt.Errorf("wipe volume %s: container error: %s", name, body.Error.Message)
+		}
+	}
+
+	return nil
 }
 
 // RunDatabase creates and starts a container with host port mapping and

--- a/internal/testutil/docker_mock.go
+++ b/internal/testutil/docker_mock.go
@@ -83,6 +83,10 @@ type MockDockerClient struct {
 	RemoveVolumeSafeFn    func(ctx context.Context, name string) error
 	RemoveVolumeSafeCalls []string // volume names removed
 
+	// WipeVolume
+	WipeVolumeFn    func(ctx context.Context, name string) error
+	WipeVolumeCalls []string // volume names wiped
+
 	// RunDatabase
 	RunDatabaseFn    func(ctx context.Context, cfg docker.RunDatabaseConfig) (string, error)
 	RunDatabaseCalls int
@@ -243,6 +247,14 @@ func (m *MockDockerClient) RemoveVolumeSafe(ctx context.Context, name string) er
 	m.RemoveVolumeSafeCalls = append(m.RemoveVolumeSafeCalls, name)
 	if m.RemoveVolumeSafeFn != nil {
 		return m.RemoveVolumeSafeFn(ctx, name)
+	}
+	return nil
+}
+
+func (m *MockDockerClient) WipeVolume(ctx context.Context, name string) error {
+	m.WipeVolumeCalls = append(m.WipeVolumeCalls, name)
+	if m.WipeVolumeFn != nil {
+		return m.WipeVolumeFn(ctx, name)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Docker volume removal frees storage but doesn't zero it — future tenants could potentially recover data
- Added `WipeVolume(ctx, name)` to the docker `Client` interface, implemented with a short-lived `busybox` container that overwrites all files with zeros before deletion
- `databases.Manager.Delete` now calls `wipeVolume` immediately before `RemoveVolume`
- Wipe is best-effort: errors are logged but don't abort deletion

## Test plan
- [x] `TestDelete_WipesVolumeBeforeRemoval` — verifies wipe is called before remove, with correct volume name
- [x] `go test ./...` passes

Closes #9