### PR TITLE
feat(#12): add POST /v1/auth/recover for API key recovery

### DIFF
--- a/AGENT_RUNBOOK.md
+++ b/AGENT_RUNBOOK.md
@@ -57,6 +57,11 @@ curl -s -X POST "$BASE_URL/v1/auth/keys" \
 # List API keys
 curl -s -H "Authorization: Bearer $API_KEY" "$BASE_URL/v1/auth/keys" | jq .
 
+# Recover access when all API keys are lost (uses bootstrap token, not API key)
+curl -s -X POST "$BASE_URL/v1/auth/recover" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "tenant@example.com", "bootstrap_token": "'"$BOOTSTRAP_TOKEN"'"}' | jq .
+
 # Deploy a service from a Docker image
 curl -s -X POST "$BASE_URL/v1/services" \
   -H "Authorization: Bearer $API_KEY" \
@@ -538,7 +543,65 @@ Your API key is wrong, revoked, or missing.
 
 1. Verify the `Authorization: Bearer <key>` header is present and formatted correctly.
 2. Check whether the key was recently rotated or deleted: `GET /v1/auth/keys`
-3. If the key is gone, you need a new one — which requires a working key to create. If you have lost all keys, you need the bootstrap token to register a new tenant.
+3. If the key is gone, you need a new one — which requires a working key to create. If you have lost all keys, use the recovery endpoint below.
+
+---
+
+## Task: Recover Access When All API Keys Are Lost
+
+If every API key for your tenant has been revoked, expired, or deleted, use the recovery endpoint to issue a new key. This does **not** require an existing API key — it uses the bootstrap token instead.
+
+This is a privileged operation: the bootstrap token is the operator secret stored in `/etc/default/ah` on the server. Treat it like a root password.
+
+### Step 1 — Get the Bootstrap Token
+
+```bash
+BOOTSTRAP_TOKEN=$(ssh root@<your-server-ip> "grep AH_BOOTSTRAP_TOKEN /etc/default/ah | cut -d= -f2")
+```
+
+### Step 2 — Call the Recovery Endpoint
+
+```bash
+curl -s -X POST "$BASE_URL/v1/auth/recover" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\": \"your-tenant@example.com\", \"bootstrap_token\": \"$BOOTSTRAP_TOKEN\"}" | jq .
+```
+
+A successful response:
+
+```json
+{
+  "id":         "key_...",
+  "key":        "keyid.secret",
+  "name":       "recovery-20260320",
+  "created_at": 1742432400
+}
+```
+
+### Step 3 — Save the New Key Immediately
+
+The `key` value is shown **once only** and cannot be retrieved again.
+
+```bash
+API_KEY="keyid.secret"   # replace with the actual value from the response
+```
+
+### Step 4 — Verify It Works
+
+```bash
+curl -s -H "Authorization: Bearer $API_KEY" "$BASE_URL/v1/tenant" | jq .
+```
+
+You should see your tenant info. The tenant account and all services/databases are intact — nothing is lost.
+
+### Notes
+
+- The recovery endpoint is rate-limited: **5 attempts per IP per hour**, 20 globally per hour. Do not hammer it.
+- An unknown email returns `401` (same as a bad token) to prevent tenant enumeration.
+- A suspended tenant account returns `403`. Contact the operator to reactivate.
+- If you receive `503`, the operator has not configured a bootstrap token. Contact them directly.
+
+---
 
 ### `429 Too Many Requests`
 
@@ -740,6 +803,8 @@ The reconciler means that manually stopping a Docker container outside the API w
 | Build sources supported | GitHub, GitLab, Bitbucket, sr.ht, Codeberg (HTTPS only) |
 | Idempotency key scope | POST, PUT, DELETE requests |
 | Service registration header | `X-Bootstrap-Token` (HMAC-compared) |
+| Key recovery rate limit (per IP) | 5 per hour |
+| Key recovery rate limit (global) | 20 per hour |
 
 ---
 

--- a/internal/api/recovery.go
+++ b/internal/api/recovery.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dennisonbertram/agentic-hosting/internal/crypto"
+)
+
+// KeyRecoverRequest is the body accepted by POST /v1/auth/recover.
+// Authentication is via bootstrap token, not an API key, so this endpoint
+// can be called even when the tenant has no valid keys remaining.
+type KeyRecoverRequest struct {
+	Email          string `json:"email"`
+	BootstrapToken string `json:"bootstrap_token"`
+}
+
+// KeyRecoverResponse mirrors CreateKeyResponse so callers can treat both
+// responses the same way.  The raw key is shown exactly once.
+type KeyRecoverResponse struct {
+	ID        string `json:"id"`
+	Key       string `json:"key"`
+	Name      string `json:"name"`
+	CreatedAt int64  `json:"created_at"`
+}
+
+// handleKeyRecover handles POST /v1/auth/recover.
+//
+// Security model:
+//   - Rate-limited by the same per-IP / global limiter used for tenant
+//     registration (5/IP/hour, 20/global/hour) — limits brute-force of the
+//     bootstrap token.
+//   - Bootstrap token is verified via HMAC-compare (no length leak).
+//   - Unknown-email and bad-token responses are deliberately identical (401)
+//     to prevent email enumeration.
+func (s *Server) handleKeyRecover(w http.ResponseWriter, r *http.Request) {
+	// Apply the same rate limiter as tenant registration to prevent
+	// brute-force of the bootstrap token via this endpoint.
+	ip := trustedRealIP(r)
+	if ok, wait := regLimiter.allow(ip); !ok {
+		secs := int(math.Ceil(wait.Seconds()))
+		if secs < 1 {
+			secs = 1
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
+		writeError(w, http.StatusTooManyRequests, "rate limit exceeded, try again later")
+		return
+	}
+
+	// Fail closed: reject if bootstrap token is not configured.
+	if s.bootstrapToken == "" {
+		writeError(w, http.StatusServiceUnavailable, "recovery temporarily unavailable")
+		return
+	}
+
+	var req KeyRecoverRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeDecodeError(w, err)
+		return
+	}
+
+	// HMAC-compare the provided token to prevent length-leak attacks.
+	provided := strings.TrimSpace(req.BootstrapToken)
+	if !hmacEqual(provided, s.bootstrapToken, s.masterKey) {
+		writeError(w, http.StatusUnauthorized, "invalid bootstrap token or email")
+		return
+	}
+
+	if !emailRegex.MatchString(req.Email) {
+		writeError(w, http.StatusBadRequest, "invalid email format")
+		return
+	}
+
+	// Look up the tenant by email. Intentionally return the same 401 as a bad
+	// token so the response cannot be used to enumerate registered emails.
+	var tenantID, tenantStatus string
+	err := s.store.StateDB.QueryRow(
+		`SELECT id, status FROM tenants WHERE email = ?`,
+		req.Email,
+	).Scan(&tenantID, &tenantStatus)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusUnauthorized, "invalid bootstrap token or email")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	if tenantStatus != "active" {
+		writeError(w, http.StatusForbidden, "tenant account is not active")
+		return
+	}
+
+	// Enforce the same per-tenant key cap that handleKeyCreate enforces.
+	var keyCount int
+	if err := s.store.StateDB.QueryRow(
+		`SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND revoked_at IS NULL`,
+		tenantID,
+	).Scan(&keyCount); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	if keyCount >= maxKeysPerTenant {
+		writeError(w, http.StatusForbidden, "maximum API keys reached; revoke unused keys first")
+		return
+	}
+
+	apiKey, keyID, err := crypto.GenerateAPIKeyWithID()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	keyHash := crypto.HashAPIKey(apiKey, s.masterKey)
+	if len(keyID) < 8 {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	prefix := keyID[:8]
+
+	now := time.Now().Unix()
+	keyName := fmt.Sprintf("recovery-%s", time.Now().UTC().Format("20060102"))
+
+	_, err = s.store.StateDB.Exec(
+		`INSERT INTO api_keys (id, tenant_id, name, key_prefix, key_hash, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		keyID, tenantID, keyName, prefix, keyHash, now,
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create recovery key")
+		return
+	}
+
+	// Return token in format "keyID.secret" for O(1) lookup.
+	// This is the only time the raw key is shown.
+	token := keyID + "." + apiKey
+
+	writeJSON(w, http.StatusCreated, KeyRecoverResponse{
+		ID:        keyID,
+		Key:       token,
+		Name:      keyName,
+		CreatedAt: now,
+	})
+}

--- a/internal/api/recovery_test.go
+++ b/internal/api/recovery_test.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dennisonbertram/agentic-hosting/internal/db"
+	"github.com/dennisonbertram/agentic-hosting/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recoverRequest builds a POST /v1/auth/recover request with a distinct
+// source IP so tests do not share the same rate-limit bucket.  The limiter
+// is a package-level singleton that persists across all tests in the package,
+// so each test must use its own IP to avoid being erroneously rate-limited.
+func recoverRequest(ip string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/recover", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// httptest.NewRequest sets RemoteAddr to "192.0.2.1:1234" (loopback-adjacent
+	// test address).  We override X-Real-Ip from a loopback RemoteAddr so
+	// trustedRealIP picks up the per-test IP.
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("X-Real-Ip", ip)
+	return req
+}
+
+func TestHandleKeyRecover(t *testing.T) {
+	const bootstrapToken = "test-bootstrap-token-for-recovery"
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+	// newServer creates a fresh in-memory DB with a single active tenant that
+	// has NO API keys — the scenario described in issue #12.
+	newServer := func(t *testing.T) *Server {
+		t.Helper()
+		stateDB := testutil.NewStateDB(t)
+		_, err := stateDB.Exec(
+			`INSERT INTO tenants (id, name, email, status, created_at, updated_at)
+			 VALUES (?, ?, ?, 'active', 1, 1)`,
+			"tenant-recover", "Recovery Tenant", "recover@example.com",
+		)
+		require.NoError(t, err)
+		_, err = stateDB.Exec(`INSERT INTO tenant_quotas (tenant_id) VALUES (?)`, "tenant-recover")
+		require.NoError(t, err)
+
+		return NewServer(ServerConfig{
+			Store:          &db.Store{StateDB: stateDB},
+			MasterKey:      masterKey,
+			DevMode:        true,
+			BootstrapToken: bootstrapToken,
+		})
+	}
+
+	t.Run("valid bootstrap token and email creates a new key", func(t *testing.T) {
+		srv := newServer(t)
+
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "recover@example.com",
+			BootstrapToken: bootstrapToken,
+		})
+		req := recoverRequest("10.0.1.1", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusCreated, rr.Code, "expected 201, got: %s", rr.Body.String())
+
+		var resp KeyRecoverResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+		assert.NotEmpty(t, resp.ID, "key ID should be set")
+		assert.NotEmpty(t, resp.Key, "raw key should be present")
+		assert.Contains(t, resp.Name, "recovery-", "name should be prefixed with recovery-")
+		assert.Greater(t, resp.CreatedAt, int64(0), "created_at should be positive unix timestamp")
+		// Key must be in "keyID.secret" format
+		assert.Contains(t, resp.Key, ".", "key should be in keyID.secret format")
+	})
+
+	t.Run("invalid bootstrap token returns 401", func(t *testing.T) {
+		srv := newServer(t)
+
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "recover@example.com",
+			BootstrapToken: "wrong-token",
+		})
+		req := recoverRequest("10.0.1.2", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("unknown email with valid bootstrap token returns 401 (no email enumeration)", func(t *testing.T) {
+		srv := newServer(t)
+
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "nobody@example.com",
+			BootstrapToken: bootstrapToken,
+		})
+		req := recoverRequest("10.0.1.3", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		// Must return 401 (not 404) to prevent tenant email enumeration.
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("invalid email format returns 400", func(t *testing.T) {
+		srv := newServer(t)
+
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "not-an-email",
+			BootstrapToken: bootstrapToken,
+		})
+		req := recoverRequest("10.0.1.4", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("suspended tenant returns 403", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+		_, err := stateDB.Exec(
+			`INSERT INTO tenants (id, name, email, status, created_at, updated_at)
+			 VALUES (?, ?, ?, 'suspended', 1, 1)`,
+			"tenant-suspended", "Suspended", "suspended@example.com",
+		)
+		require.NoError(t, err)
+		_, err = stateDB.Exec(`INSERT INTO tenant_quotas (tenant_id) VALUES (?)`, "tenant-suspended")
+		require.NoError(t, err)
+
+		srv := NewServer(ServerConfig{
+			Store:          &db.Store{StateDB: stateDB},
+			MasterKey:      masterKey,
+			DevMode:        true,
+			BootstrapToken: bootstrapToken,
+		})
+
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "suspended@example.com",
+			BootstrapToken: bootstrapToken,
+		})
+		req := recoverRequest("10.0.1.5", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("empty bootstrap token in server config returns 503", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+		srv := NewServer(ServerConfig{
+			Store:     &db.Store{StateDB: stateDB},
+			MasterKey: masterKey,
+			DevMode:   true,
+			// BootstrapToken intentionally omitted — recovery must be unavailable
+		})
+
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "anyone@example.com",
+			BootstrapToken: "anything",
+		})
+		req := recoverRequest("10.0.1.6", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	})
+
+	t.Run("recovered key is usable for authenticated requests", func(t *testing.T) {
+		srv := newServer(t)
+
+		// Step 1 — recover a key
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "recover@example.com",
+			BootstrapToken: bootstrapToken,
+		})
+		recoverReq := recoverRequest("10.0.1.7", body)
+		recoverRR := httptest.NewRecorder()
+		srv.ServeHTTP(recoverRR, recoverReq)
+		require.Equal(t, http.StatusCreated, recoverRR.Code, "recovery should return 201, got: %s", recoverRR.Body.String())
+
+		var resp KeyRecoverResponse
+		require.NoError(t, json.NewDecoder(recoverRR.Body).Decode(&resp))
+
+		// Step 2 — use the recovered key to call an authenticated endpoint
+		tenantReq := httptest.NewRequest(http.MethodGet, "/v1/tenant", nil)
+		tenantReq.Header.Set("Authorization", "Bearer "+resp.Key)
+		tenantRR := httptest.NewRecorder()
+		srv.ServeHTTP(tenantRR, tenantReq)
+
+		assert.Equal(t, http.StatusOK, tenantRR.Code,
+			"recovered key should authenticate successfully: %s", tenantRR.Body.String())
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -141,6 +141,9 @@ func (s *Server) setupRoutes() {
 		r.Use(chimw.Timeout(30 * time.Second))
 		r.Get("/v1/system/health", s.handleHealth)
 		r.Post("/v1/tenants/register", s.handleTenantRegister)
+		// Recovery endpoint: authenticated by bootstrap token, not an API key.
+		// Allows tenants who have lost all their keys to obtain a new one.
+		r.Post("/v1/auth/recover", s.handleKeyRecover)
 	})
 
 	// Authenticated short-lived routes keep the standard request timeout.


### PR DESCRIPTION
## Summary
- Previously there was no recovery path when a tenant lost all API keys — only option was re-registration (losing all data)
- Adds `POST /v1/auth/recover` authenticated with bootstrap token (not existing key) to create a new key
- No email enumeration: returns 401 for both bad token and unknown email
- Rate-limited the same as tenant registration (5/IP/hour)
- Key count check prevents bypassing the 20-key cap
- AGENT_RUNBOOK.md updated with full recovery procedure

## Test plan
- [x] Valid token + valid email → 201 + working key
- [x] Invalid bootstrap token → 401
- [x] Unknown email → 401 (no enumeration)
- [x] Invalid email format → 400
- [x] Suspended tenant → 403
- [x] No bootstrap token configured → 503
- [x] End-to-end: recovered key authenticates GET /v1/tenant
- [x] `go test ./...` passes

Closes #12