### PR TITLE
feat(#67): add dev-only localhost routing when baseDomain is unset

### DIFF
--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -184,19 +184,32 @@ func traefikLabels(serviceID, dnsLabel, baseDomain string, port int) map[string]
 
 // writeTraefikRoute writes a Traefik dynamic config file for a service.
 // The file is read by Traefik's file provider and hot-reloaded.
-// Returns nil (no-op) in localhost mode or when traefikConfigDir is empty.
+//
+// Two modes:
+//   - Production (baseDomain set): routes {dnsLabel}.{baseDomain} via HTTPS/letsencrypt.
+//   - Localhost  (baseDomain empty): routes {serviceID}.localhost via HTTP (web entrypoint).
+//     This makes dev-mode services reachable at http://{serviceID}.localhost.
+//
+// Returns nil (no-op) when traefikConfigDir is empty.
 func (m *Manager) writeTraefikRoute(serviceID, tenantID, dnsLabel, baseDomain string, port int) error {
-	if m.traefikConfigDir == "" || dnsLabel == "" || baseDomain == "" {
+	if m.traefikConfigDir == "" {
 		return nil
 	}
-	if !isDNSLabelSafe(dnsLabel) || !baseDomainRe.MatchString(baseDomain) {
-		return nil
-	}
-	host := fmt.Sprintf("%s.%s", dnsLabel, baseDomain)
+
 	containerName := fmt.Sprintf("ah-%s-%s", tenantID, serviceID)
 	portStr := strconv.Itoa(port)
 
-	content := fmt.Sprintf(`http:
+	var content string
+	if baseDomain != "" {
+		// Production mode: HTTPS with Let's Encrypt
+		if dnsLabel == "" {
+			return nil
+		}
+		if !isDNSLabelSafe(dnsLabel) || !baseDomainRe.MatchString(baseDomain) {
+			return nil
+		}
+		host := fmt.Sprintf("%s.%s", dnsLabel, baseDomain)
+		content = fmt.Sprintf(`http:
   routers:
     svc-%s:
       rule: "Host(`+"`%s`"+`)"
@@ -211,6 +224,22 @@ func (m *Manager) writeTraefikRoute(serviceID, tenantID, dnsLabel, baseDomain st
         servers:
           - url: "http://%s:%s"
 `, serviceID, host, serviceID, serviceID, containerName, portStr)
+	} else {
+		// Localhost mode: HTTP-only, {serviceID}.localhost
+		content = fmt.Sprintf(`http:
+  routers:
+    svc-%s:
+      rule: "Host(`+"`%s.localhost`"+`)"
+      entryPoints:
+        - web
+      service: svc-%s
+  services:
+    svc-%s:
+      loadBalancer:
+        servers:
+          - url: "http://%s:%s"
+`, serviceID, serviceID, serviceID, serviceID, containerName, portStr)
+	}
 
 	// Write atomically: write to a temp file then rename to avoid Traefik
 	// reading a partially-written config during a hot reload.

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -298,7 +298,7 @@ func TestWriteTraefikRoute(t *testing.T) {
 		assert.Contains(t, content, "letsencrypt")
 	})
 
-	t.Run("no-op without baseDomain", func(t *testing.T) {
+	t.Run("writes localhost route without baseDomain", func(t *testing.T) {
 		stateDB := testutil.NewStateDB(t)
 		seedTenant(t, stateDB)
 		mock := &testutil.MockDockerClient{}
@@ -309,9 +309,15 @@ func TestWriteTraefikRoute(t *testing.T) {
 		err := mgr.writeTraefikRoute("svc123", "tenant1", "my-app", "", 8080)
 		require.NoError(t, err)
 
-		// No file should be written
-		files, _ := os.ReadDir(dir)
-		assert.Empty(t, files)
+		data, err := os.ReadFile(dir + "/svc123.yml")
+		require.NoError(t, err)
+		content := string(data)
+		assert.Contains(t, content, "Host(`svc123.localhost`)")
+		assert.Contains(t, content, "web", "localhost mode should use HTTP entrypoint")
+		assert.NotContains(t, content, "websecure", "localhost mode should not use HTTPS entrypoint")
+		assert.NotContains(t, content, "letsencrypt", "localhost mode should not use TLS")
+		assert.Contains(t, content, "ah-tenant1-svc123")
+		assert.Contains(t, content, "8080")
 	})
 
 	t.Run("no-op without traefikConfigDir", func(t *testing.T) {
@@ -323,6 +329,37 @@ func TestWriteTraefikRoute(t *testing.T) {
 		mgr := NewManager(stateDB, mock, masterKey, "example.com", "")
 		err := mgr.writeTraefikRoute("svc123", "tenant1", "my-app", "example.com", 8080)
 		require.NoError(t, err)
+	})
+
+	t.Run("no-op without traefikConfigDir in localhost mode", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+		seedTenant(t, stateDB)
+		mock := &testutil.MockDockerClient{}
+		masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+		mgr := NewManager(stateDB, mock, masterKey, "", "")
+		err := mgr.writeTraefikRoute("svc123", "tenant1", "", "", 8080)
+		require.NoError(t, err)
+	})
+
+	t.Run("localhost route uses serviceID not dnsLabel", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+		seedTenant(t, stateDB)
+		mock := &testutil.MockDockerClient{}
+		masterKey := []byte("0123456789abcdef0123456789abcdef")
+		dir := t.TempDir()
+
+		mgr := NewManager(stateDB, mock, masterKey, "", dir)
+		// dnsLabel is empty in localhost mode (no baseDomain during Create)
+		err := mgr.writeTraefikRoute("svc-abc-123", "tenant1", "", "", 3000)
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(dir + "/svc-abc-123.yml")
+		require.NoError(t, err)
+		content := string(data)
+		assert.Contains(t, content, "Host(`svc-abc-123.localhost`)")
+		assert.Contains(t, content, "3000")
+		assert.Contains(t, content, "ah-tenant1-svc-abc-123")
 	})
 }
 


### PR DESCRIPTION
## Summary
- `writeTraefikRoute()` now writes a Traefik file-provider route in localhost mode (baseDomain empty)
- Localhost routes use `Host(`{serviceID}.localhost`)` on the `web` (HTTP) entrypoint — no TLS
- Production HTTPS routing via `websecure`/letsencrypt is completely unchanged
- All call sites (Deploy, DeployImage, Restart) already pass through `writeTraefikRoute()` so they benefit automatically

Closes #67

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/services/...` passes (all 30 tests)
- [x] New test: localhost route is written with correct Host rule and HTTP entrypoint
- [x] New test: localhost mode is a no-op when traefikConfigDir is empty
- [x] New test: localhost route uses serviceID (not dnsLabel) in Host rule
- [x] Existing test: production mode writes HTTPS route with letsencrypt (unchanged)
- [x] Existing test: deleteTraefikRoute works for both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)