### PR TITLE
chore(#21): add cron-friendly health check script with webhook alerting

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,6 +23,7 @@ export AH_URL="http://localhost:8080"
 | `status.sh` | Show status of all services and databases |
 | `logs.sh` | Stream build logs for a service |
 | `db-provision.sh` | Provision a database and wire it to a service |
+| `health-check.sh` | Cron-friendly health check with webhook alerting |
 
 ## Usage
 
@@ -49,4 +50,67 @@ AH_BOOTSTRAP_TOKEN=<token> ./scripts/register.sh my-tenant me@example.com
 
 # Provision Redis and wire to service
 ./scripts/db-provision.sh my-app redis
+```
+
+## Health Check Script
+
+`health-check.sh` performs five checks and exits 0 on success or 1 on failure. On failure it POSTs a machine-readable JSON payload to the configured webhook URL.
+
+### Checks performed
+
+1. **Health API** -- `GET /v1/system/health` returns `{"status":"ok"}`
+2. **systemd service** -- `systemctl is-active ah` shows `active`
+3. **Infrastructure containers** -- `docker ps` contains `paas-traefik` and `paas-registry`
+4. **Disk usage** -- warns at 80%, fails at 90% (configurable)
+5. **Public HTTPS** -- base domain returns 2xx/3xx (if `AH_BASE_DOMAIN` is set)
+
+### Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ALERT_WEBHOOK_URL` | Yes (unless `--dry-run`) | -- | POST endpoint for failure alerts |
+| `AH_API_PORT` | No | `9090` | Local health API port |
+| `AH_SERVICE_NAME` | No | `ah` | systemd service name |
+| `AH_BASE_DOMAIN` | No | -- | Public domain to probe via HTTPS |
+| `AH_DISK_WARN_PCT` | No | `80` | Disk usage warning threshold (%) |
+| `AH_DISK_FAIL_PCT` | No | `90` | Disk usage failure threshold (%) |
+
+### Cron setup
+
+Run every 5 minutes (adjust to taste):
+
+```cron
+*/5 * * * * ALERT_WEBHOOK_URL="https://hooks.example.com/alert" AH_BASE_DOMAIN="agentic.hosting" /opt/agentic-hosting/scripts/health-check.sh >> /var/log/ah-health.log 2>&1
+```
+
+Or with all options:
+
+```cron
+*/5 * * * * ALERT_WEBHOOK_URL="https://hooks.example.com/alert" AH_API_PORT=9090 AH_SERVICE_NAME=ah AH_BASE_DOMAIN="agentic.hosting" AH_DISK_WARN_PCT=80 AH_DISK_FAIL_PCT=90 /opt/agentic-hosting/scripts/health-check.sh >> /var/log/ah-health.log 2>&1
+```
+
+### Dry-run mode
+
+Test locally without firing the webhook:
+
+```bash
+./scripts/health-check.sh --dry-run
+```
+
+This runs all checks and prints what would be sent to the webhook, but does not actually POST.
+
+### Webhook payload
+
+On failure the script sends a JSON POST body:
+
+```json
+{
+  "event": "health_check_failed",
+  "hostname": "prod-01",
+  "timestamp": "2026-03-20T12:00:00Z",
+  "failure_count": 1,
+  "warning_count": 0,
+  "failures": ["Health API returned HTTP 000 (expected 200)"],
+  "warnings": []
+}
 ```

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# health-check.sh — cron-friendly health check for agentic-hosting
+#
+# Checks:
+#   1. GET /v1/system/health returns {"status":"ok"}
+#   2. systemctl is-active ah shows active
+#   3. docker ps contains expected infra containers (paas-traefik, paas-registry)
+#   4. Disk usage thresholds (warn 80%, fail 90%)
+#   5. Public HTTPS endpoint responds (if AH_BASE_DOMAIN is set)
+#
+# Environment variables:
+#   ALERT_WEBHOOK_URL  — POST webhook URL for failure alerts (required unless --dry-run)
+#   AH_API_PORT        — health API port (default: 9090)
+#   AH_SERVICE_NAME    — systemd service name (default: ah)
+#   AH_BASE_DOMAIN     — public domain to check via HTTPS (optional)
+#   AH_DISK_WARN_PCT   — disk warning threshold (default: 80)
+#   AH_DISK_FAIL_PCT   — disk failure threshold (default: 90)
+#
+# Usage:
+#   ./scripts/health-check.sh              # run checks, alert on failure
+#   ./scripts/health-check.sh --dry-run    # run checks, print results, skip webhook
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+API_PORT="${AH_API_PORT:-9090}"
+SERVICE_NAME="${AH_SERVICE_NAME:-ah}"
+BASE_DOMAIN="${AH_BASE_DOMAIN:-}"
+DISK_WARN_PCT="${AH_DISK_WARN_PCT:-80}"
+DISK_FAIL_PCT="${AH_DISK_FAIL_PCT:-90}"
+WEBHOOK_URL="${ALERT_WEBHOOK_URL:-}"
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+FAILURES=()    # array of failure messages
+WARNINGS=()    # array of warning messages
+HOSTNAME_STR=$(hostname 2>/dev/null || echo "unknown")
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log() {
+  echo "[health-check] $*"
+}
+
+fail() {
+  FAILURES+=("$1")
+  log "FAIL: $1"
+}
+
+warn() {
+  WARNINGS+=("$1")
+  log "WARN: $1"
+}
+
+pass() {
+  log "OK:   $1"
+}
+
+# ---------------------------------------------------------------------------
+# Check 1: Health API
+# ---------------------------------------------------------------------------
+check_health_api() {
+  local url="http://127.0.0.1:${API_PORT}/v1/system/health"
+  local response
+  local http_code
+
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$url" 2>/dev/null) || true
+
+  if [[ "$http_code" != "200" ]]; then
+    fail "Health API returned HTTP ${http_code:-timeout} (expected 200)"
+    return
+  fi
+
+  response=$(curl -sf --max-time 5 "$url" 2>/dev/null) || true
+  local status
+  status=$(echo "$response" | python3 -c "import json,sys; print(json.load(sys.stdin).get('status',''))" 2>/dev/null) || true
+
+  if [[ "$status" != "ok" ]]; then
+    fail "Health API status is '${status}' (expected 'ok')"
+    return
+  fi
+
+  pass "Health API /v1/system/health returns ok"
+}
+
+# ---------------------------------------------------------------------------
+# Check 2: systemd service
+# ---------------------------------------------------------------------------
+check_systemd() {
+  if ! command -v systemctl &>/dev/null; then
+    warn "systemctl not found — skipping service check"
+    return
+  fi
+
+  local state
+  state=$(systemctl is-active "$SERVICE_NAME" 2>/dev/null) || true
+
+  if [[ "$state" != "active" ]]; then
+    fail "systemd service '${SERVICE_NAME}' is '${state}' (expected 'active')"
+    return
+  fi
+
+  pass "systemd service '${SERVICE_NAME}' is active"
+}
+
+# ---------------------------------------------------------------------------
+# Check 3: Infrastructure containers
+# ---------------------------------------------------------------------------
+check_containers() {
+  if ! command -v docker &>/dev/null; then
+    fail "docker command not found"
+    return
+  fi
+
+  local running
+  if command -v timeout &>/dev/null; then
+    running=$(timeout 10 docker ps --format '{{.Names}}' 2>/dev/null) || true
+  else
+    running=$(docker ps --format '{{.Names}}' 2>/dev/null) || true
+  fi
+
+  if [[ -z "$running" ]]; then
+    fail "docker ps returned no running containers (or Docker is unreachable)"
+    return
+  fi
+
+  local missing=()
+  for container in paas-traefik paas-registry; do
+    if ! echo "$running" | grep -qx "$container"; then
+      missing+=("$container")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    fail "Missing infrastructure containers: ${missing[*]}"
+    return
+  fi
+
+  pass "Infrastructure containers running: paas-traefik, paas-registry"
+}
+
+# ---------------------------------------------------------------------------
+# Check 4: Disk usage
+# ---------------------------------------------------------------------------
+check_disk() {
+  local disk_line
+  disk_line=$(df -P / 2>/dev/null | tail -1) || true
+
+  if [[ -z "$disk_line" ]]; then
+    fail "Could not read disk usage via df"
+    return
+  fi
+
+  # df -P output: Filesystem 1024-blocks Used Available Capacity Mounted-on
+  local used_pct
+  used_pct=$(echo "$disk_line" | awk '{print $5}' | tr -d '%')
+
+  if [[ -z "$used_pct" ]] || ! [[ "$used_pct" =~ ^[0-9]+$ ]]; then
+    fail "Could not parse disk usage percentage"
+    return
+  fi
+
+  if [[ "$used_pct" -ge "$DISK_FAIL_PCT" ]]; then
+    fail "Disk usage at ${used_pct}% (threshold: ${DISK_FAIL_PCT}%)"
+    return
+  fi
+
+  if [[ "$used_pct" -ge "$DISK_WARN_PCT" ]]; then
+    warn "Disk usage at ${used_pct}% (warning threshold: ${DISK_WARN_PCT}%)"
+    # Still pass — warnings don't cause non-zero exit
+    pass "Disk usage at ${used_pct}% (warning)"
+    return
+  fi
+
+  pass "Disk usage at ${used_pct}%"
+}
+
+# ---------------------------------------------------------------------------
+# Check 5: Public HTTPS endpoint
+# ---------------------------------------------------------------------------
+check_public_https() {
+  if [[ -z "$BASE_DOMAIN" ]]; then
+    log "SKIP: AH_BASE_DOMAIN not set — skipping public HTTPS check"
+    return
+  fi
+
+  local url="https://${BASE_DOMAIN}/"
+  local http_code
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$url" 2>/dev/null) || true
+
+  if [[ -z "$http_code" ]] || [[ "$http_code" == "000" ]]; then
+    fail "Public HTTPS endpoint ${url} is unreachable (connection failed or timed out)"
+    return
+  fi
+
+  # Accept any 2xx or 3xx as healthy
+  if [[ "$http_code" =~ ^[23] ]]; then
+    pass "Public HTTPS endpoint ${url} returned HTTP ${http_code}"
+    return
+  fi
+
+  fail "Public HTTPS endpoint ${url} returned HTTP ${http_code}"
+}
+
+# ---------------------------------------------------------------------------
+# Build webhook payload
+# ---------------------------------------------------------------------------
+build_payload() {
+  local failures_json="["
+  local first=true
+  for f in "${FAILURES[@]}"; do
+    if $first; then first=false; else failures_json+=","; fi
+    # Escape double quotes and backslashes in the message
+    local escaped
+    escaped=$(echo "$f" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    failures_json+="\"${escaped}\""
+  done
+  failures_json+="]"
+
+  local warnings_json="["
+  first=true
+  for w in "${WARNINGS[@]}"; do
+    if $first; then first=false; else warnings_json+=","; fi
+    local escaped
+    escaped=$(echo "$w" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    warnings_json+="\"${escaped}\""
+  done
+  warnings_json+="]"
+
+  cat <<ENDJSON
+{
+  "event": "health_check_failed",
+  "hostname": "${HOSTNAME_STR}",
+  "timestamp": "${TIMESTAMP}",
+  "failure_count": ${#FAILURES[@]},
+  "warning_count": ${#WARNINGS[@]},
+  "failures": ${failures_json},
+  "warnings": ${warnings_json}
+}
+ENDJSON
+}
+
+# ---------------------------------------------------------------------------
+# Send webhook alert
+# ---------------------------------------------------------------------------
+send_alert() {
+  local payload
+  payload=$(build_payload)
+
+  if $DRY_RUN; then
+    log "DRY-RUN: Would send webhook to ${WEBHOOK_URL:-<not set>}"
+    log "DRY-RUN: Payload:"
+    echo "$payload"
+    return
+  fi
+
+  if [[ -z "$WEBHOOK_URL" ]]; then
+    log "ERROR: ALERT_WEBHOOK_URL not set — cannot send alert"
+    echo "$payload" >&2
+    return
+  fi
+
+  local http_code
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+    --max-time 10 \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$WEBHOOK_URL" 2>/dev/null) || true
+
+  if [[ "$http_code" =~ ^2 ]]; then
+    log "Alert sent to webhook (HTTP ${http_code})"
+  else
+    log "ERROR: Webhook returned HTTP ${http_code:-timeout}"
+    echo "$payload" >&2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  log "Starting health checks at ${TIMESTAMP}"
+  log "Host: ${HOSTNAME_STR}, API port: ${API_PORT}, Service: ${SERVICE_NAME}"
+  if $DRY_RUN; then
+    log "Mode: --dry-run (webhook will not fire)"
+  fi
+  echo ""
+
+  check_health_api
+  check_systemd
+  check_containers
+  check_disk
+  check_public_https
+
+  echo ""
+  log "Results: ${#FAILURES[@]} failure(s), ${#WARNINGS[@]} warning(s)"
+
+  if [[ ${#FAILURES[@]} -gt 0 ]]; then
+    echo ""
+    send_alert
+    exit 1
+  fi
+
+  exit 0
+}
+
+main


### PR DESCRIPTION
## Summary
- Adds `scripts/health-check.sh` for cron-based monitoring
- Checks: health API, systemd status, Docker infrastructure containers, disk usage, public HTTPS
- Webhook alerting via `ALERT_WEBHOOK_URL` env var (JSON payload)
- Supports `--dry-run` mode for local validation
- Updates `scripts/README.md` with full documentation, env var table, and cron examples

Closes #21

## Test plan
- [ ] Script exits 0 on healthy system (all checks pass on production server)
- [ ] Script exits non-zero on failure (e.g., stop ah service, verify exit 1)
- [ ] `--dry-run` mode works without webhook (prints payload to stdout)
- [ ] Webhook payload is valid JSON (`build_payload` output parses with `jq`)
- [ ] Disk warning at 80% produces WARN but still exits 0
- [ ] Disk failure at 90% produces FAIL and exits 1
- [ ] Missing Docker containers detected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)