### PR TITLE
test(#80): add rate limit test coverage

### DIFF
--- a/internal/api/tenants_test.go
+++ b/internal/api/tenants_test.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/dennisonbertram/agentic-hosting/internal/cache"
+	"github.com/dennisonbertram/agentic-hosting/internal/db"
+	"github.com/dennisonbertram/agentic-hosting/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegistrationLimiter_AllowsWithinPerIPLimit verifies that an IP can
+// register up to regMaxPerIPPerHour (5) times before being rate-limited.
+func TestRegistrationLimiter_AllowsWithinPerIPLimit(t *testing.T) {
+	rl := &registrationLimiter{
+		entries: cache.New[string, *regEntry](regMaxEntries),
+	}
+
+	for i := 0; i < regMaxPerIPPerHour; i++ {
+		ok, _ := rl.allow("192.168.1.1")
+		assert.True(t, ok, "registration %d should be allowed", i+1)
+	}
+
+	// The 6th should be rejected
+	ok, wait := rl.allow("192.168.1.1")
+	assert.False(t, ok, "registration beyond per-IP limit should be rejected")
+	assert.Greater(t, wait.Seconds(), float64(0),
+		"Retry-After wait duration should be positive when rate-limited")
+}
+
+// TestRegistrationLimiter_PerIPIsolation verifies that different IPs have
+// independent rate limit buckets. Exhausting one IP's quota does not affect
+// another IP.
+func TestRegistrationLimiter_PerIPIsolation(t *testing.T) {
+	rl := &registrationLimiter{
+		entries: cache.New[string, *regEntry](regMaxEntries),
+	}
+
+	// Exhaust IP-A's per-IP quota
+	for i := 0; i < regMaxPerIPPerHour; i++ {
+		ok, _ := rl.allow("10.0.0.1")
+		require.True(t, ok)
+	}
+
+	// IP-A should now be blocked
+	ok, _ := rl.allow("10.0.0.1")
+	assert.False(t, ok, "IP-A should be rate-limited after 5 registrations")
+
+	// IP-B should still be allowed
+	ok, _ = rl.allow("10.0.0.2")
+	assert.True(t, ok, "IP-B should be unaffected by IP-A's exhaustion")
+}
+
+// TestRegistrationLimiter_GlobalLimitEnforced verifies the global per-hour
+// cap (20 registrations across all IPs). Even if individual IPs haven't hit
+// their per-IP limits, the global cap stops all registrations.
+func TestRegistrationLimiter_GlobalLimitEnforced(t *testing.T) {
+	rl := &registrationLimiter{
+		entries: cache.New[string, *regEntry](regMaxEntries),
+	}
+
+	// Use distinct IPs to avoid per-IP limits. Each IP registers up to its
+	// per-IP limit (5), and we need 20 total to hit the global limit.
+	for i := 0; i < regGlobalPerHour; i++ {
+		ip := "10.0." + strconv.Itoa(i/regMaxPerIPPerHour) + "." + strconv.Itoa(i%regMaxPerIPPerHour+1)
+		ok, _ := rl.allow(ip)
+		require.True(t, ok, "registration %d (ip=%s) should pass under global limit", i+1, ip)
+	}
+
+	// 21st registration from a fresh IP should be rejected by global limit
+	ok, wait := rl.allow("172.16.0.1")
+	assert.False(t, ok, "registration beyond global limit should be rejected")
+	assert.Greater(t, wait.Seconds(), float64(0),
+		"wait duration should be positive when global limit is hit")
+}
+
+// TestRegistrationLimiter_RetryAfterDuration verifies that the wait duration
+// returned by allow() is positive and bounded by the 1-hour window.
+func TestRegistrationLimiter_RetryAfterDuration(t *testing.T) {
+	rl := &registrationLimiter{
+		entries: cache.New[string, *regEntry](regMaxEntries),
+	}
+
+	// Exhaust the per-IP limit
+	for i := 0; i < regMaxPerIPPerHour; i++ {
+		ok, _ := rl.allow("10.10.10.10")
+		require.True(t, ok)
+	}
+
+	ok, wait := rl.allow("10.10.10.10")
+	require.False(t, ok)
+
+	// Wait should be between 0 and 1 hour (regWindow)
+	assert.Greater(t, wait.Seconds(), float64(0))
+	assert.LessOrEqual(t, wait.Seconds(), regWindow.Seconds(),
+		"wait duration should not exceed the rate limit window")
+}
+
+// TestRegistrationEndpoint_RateLimitReturns429 exercises the full HTTP handler
+// path for registration rate limiting. After 5 requests from the same IP,
+// subsequent requests should receive 429 with a Retry-After header.
+func TestRegistrationEndpoint_RateLimitReturns429(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+	// Reset the global registration limiter to avoid pollution from other tests.
+	// Save and restore afterwards.
+	savedLimiter := regLimiter
+	regLimiter = &registrationLimiter{
+		entries: cache.New[string, *regEntry](regMaxEntries),
+	}
+	t.Cleanup(func() { regLimiter = savedLimiter })
+
+	srv := NewServer(ServerConfig{
+		Store:            &db.Store{StateDB: stateDB},
+		MasterKey:        masterKey,
+		DevMode:          true,
+		OpenRegistration: true,
+	})
+
+	body := func() *bytes.Reader {
+		return bytes.NewReader([]byte(`{"name":"Test User","email":"user@example.com"}`))
+	}
+
+	// First regMaxPerIPPerHour (5) requests should succeed (or fail for other
+	// reasons like duplicate email, but NOT with 429). We use unique emails.
+	for i := 0; i < regMaxPerIPPerHour; i++ {
+		payload, _ := json.Marshal(map[string]string{
+			"name":  "Test User",
+			"email": "user" + strconv.Itoa(i) + "@example.com",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/tenants/register", bytes.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "192.168.1.100:12345"
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		// Should be 201 (success), not 429
+		assert.NotEqual(t, http.StatusTooManyRequests, rec.Code,
+			"registration %d should not be rate-limited", i+1)
+	}
+
+	// 6th request should be rate-limited
+	req := httptest.NewRequest(http.MethodPost, "/v1/tenants/register", body())
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.168.1.100:12345"
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code,
+		"6th registration from same IP should return 429")
+	assert.NotEmpty(t, rec.Header().Get("Retry-After"),
+		"429 response must include Retry-After header")
+
+	// Verify the body is valid JSON with an error field
+	var errResp map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Contains(t, errResp["error"], "rate limit",
+		"error message should mention rate limit")
+}
+
+// TestRegistrationEndpoint_DifferentIPsNotAffected verifies that rate limiting
+// one IP does not prevent a different IP from registering.
+func TestRegistrationEndpoint_DifferentIPsNotAffected(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+	savedLimiter := regLimiter
+	regLimiter = &registrationLimiter{
+		entries: cache.New[string, *regEntry](regMaxEntries),
+	}
+	t.Cleanup(func() { regLimiter = savedLimiter })
+
+	srv := NewServer(ServerConfig{
+		Store:            &db.Store{StateDB: stateDB},
+		MasterKey:        masterKey,
+		DevMode:          true,
+		OpenRegistration: true,
+	})
+
+	// Exhaust IP-A's registration quota
+	for i := 0; i < regMaxPerIPPerHour; i++ {
+		payload, _ := json.Marshal(map[string]string{
+			"name":  "User A",
+			"email": "usera" + strconv.Itoa(i) + "@example.com",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/tenants/register", bytes.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "10.0.0.1:12345"
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		require.NotEqual(t, http.StatusTooManyRequests, rec.Code)
+	}
+
+	// Confirm IP-A is blocked
+	payload, _ := json.Marshal(map[string]string{
+		"name":  "User A Extra",
+		"email": "usera-extra@example.com",
+	})
+	reqA := httptest.NewRequest(http.MethodPost, "/v1/tenants/register", bytes.NewReader(payload))
+	reqA.Header.Set("Content-Type", "application/json")
+	reqA.RemoteAddr = "10.0.0.1:12345"
+	recA := httptest.NewRecorder()
+	srv.ServeHTTP(recA, reqA)
+	require.Equal(t, http.StatusTooManyRequests, recA.Code)
+
+	// IP-B should still be allowed to register
+	payload, _ = json.Marshal(map[string]string{
+		"name":  "User B",
+		"email": "userb@example.com",
+	})
+	reqB := httptest.NewRequest(http.MethodPost, "/v1/tenants/register", bytes.NewReader(payload))
+	reqB.Header.Set("Content-Type", "application/json")
+	reqB.RemoteAddr = "10.0.0.2:12345"
+	recB := httptest.NewRecorder()
+	srv.ServeHTTP(recB, reqB)
+
+	assert.NotEqual(t, http.StatusTooManyRequests, recB.Code,
+		"IP-B should not be rate-limited when only IP-A exhausted its quota")
+}

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -2,6 +2,8 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -104,6 +106,204 @@ func TestRateLimit_MissingTenantIDFailsClosed(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// TestRateLimit_ProductionConfig_200BurstThenThrottled verifies the production
+// configuration (100 req/s, burst=200) allows all 200 burst requests and then
+// returns 429 for the next request. This exercises the exact values used in
+// server.go NewRateLimiter(100, 200).
+func TestRateLimit_ProductionConfig_200BurstThenThrottled(t *testing.T) {
+	rl := NewRateLimiter(100, 200)
+	handler := newRateLimitHandler(rl)
+
+	// All 200 burst requests should pass
+	for i := 0; i < 200; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req = req.WithContext(contextWithTenant("tenant-burst"))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code, "burst request %d should pass", i+1)
+	}
+
+	// Request 201 should be throttled (burst exhausted, not enough time for refill)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(contextWithTenant("tenant-burst"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code,
+		"request beyond burst capacity should return 429")
+}
+
+// TestRateLimit_XRateLimitHeaders verifies that X-RateLimit-Limit and
+// X-RateLimit-Remaining headers are set on every response, both for allowed
+// and throttled requests.
+func TestRateLimit_XRateLimitHeaders(t *testing.T) {
+	rl := NewRateLimiter(100, 2) // burst=2 for fast exhaustion
+	handler := newRateLimitHandler(rl)
+
+	// First request — should pass with rate limit headers
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req1 = req1.WithContext(contextWithTenant("tenant-headers"))
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	require.Equal(t, http.StatusOK, rec1.Code)
+	assert.Equal(t, "100", rec1.Header().Get("X-RateLimit-Limit"),
+		"X-RateLimit-Limit should reflect the configured rate")
+	remaining := rec1.Header().Get("X-RateLimit-Remaining")
+	require.NotEmpty(t, remaining, "X-RateLimit-Remaining must be set on 200")
+	remVal, err := strconv.Atoi(remaining)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, remVal, 0, "remaining should be non-negative")
+
+	// Exhaust the burst
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2 = req2.WithContext(contextWithTenant("tenant-headers"))
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	req3 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req3 = req3.WithContext(contextWithTenant("tenant-headers"))
+	rec3 := httptest.NewRecorder()
+	handler.ServeHTTP(rec3, req3)
+
+	// Even on 429 the rate limit headers should still be set
+	assert.Equal(t, http.StatusTooManyRequests, rec3.Code)
+	assert.Equal(t, "100", rec3.Header().Get("X-RateLimit-Limit"),
+		"X-RateLimit-Limit should be present on 429 responses too")
+	assert.NotEmpty(t, rec3.Header().Get("X-RateLimit-Remaining"),
+		"X-RateLimit-Remaining should be present on 429 responses too")
+}
+
+// TestRateLimit_429ResponseIsJSON verifies the 429 response body is valid JSON
+// with an "error" field matching the expected rate limit message.
+func TestRateLimit_429ResponseIsJSON(t *testing.T) {
+	rl := NewRateLimiter(10, 1)
+	handler := newRateLimitHandler(rl)
+
+	// Consume the burst
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req1 = req1.WithContext(contextWithTenant("tenant-json"))
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	// Trigger 429
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2 = req2.WithContext(contextWithTenant("tenant-json"))
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	require.Equal(t, http.StatusTooManyRequests, rec2.Code)
+	assert.Equal(t, "application/json", rec2.Header().Get("Content-Type"))
+
+	var errResp map[string]string
+	require.NoError(t, json.NewDecoder(rec2.Body).Decode(&errResp),
+		"429 body must be valid JSON")
+	assert.Equal(t, "rate limit exceeded", errResp["error"])
+}
+
+// TestRateLimit_PerTenantIsolationUnderLoad verifies that exhausting one
+// tenant's rate limit bucket does not affect another tenant, even when both
+// are being processed by the same RateLimiter instance. This is the key
+// multi-tenant isolation guarantee.
+func TestRateLimit_PerTenantIsolationUnderLoad(t *testing.T) {
+	rl := NewRateLimiter(100, 10) // burst=10
+	handler := newRateLimitHandler(rl)
+
+	// Exhaust tenant-A's burst completely
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req = req.WithContext(contextWithTenant("tenant-A"))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	// Confirm tenant-A is now rate-limited
+	reqA := httptest.NewRequest(http.MethodGet, "/", nil)
+	reqA = reqA.WithContext(contextWithTenant("tenant-A"))
+	recA := httptest.NewRecorder()
+	handler.ServeHTTP(recA, reqA)
+	require.Equal(t, http.StatusTooManyRequests, recA.Code,
+		"tenant-A should be rate-limited after exhausting burst")
+
+	// tenant-B should still be fully unaffected — all 10 burst requests pass
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req = req.WithContext(contextWithTenant("tenant-B"))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code,
+			"tenant-B request %d should pass (independent bucket)", i+1)
+	}
+
+	// tenant-C should also be fully independent
+	reqC := httptest.NewRequest(http.MethodGet, "/", nil)
+	reqC = reqC.WithContext(contextWithTenant("tenant-C"))
+	recC := httptest.NewRecorder()
+	handler.ServeHTTP(recC, reqC)
+	assert.Equal(t, http.StatusOK, recC.Code,
+		"tenant-C should be unaffected by tenant-A being rate-limited")
+}
+
+// TestRateLimit_MultipleTenantsConcurrentBuckets verifies that the LRU-based
+// rate limiter correctly maintains separate buckets for many distinct tenants
+// (not just 2-3).
+func TestRateLimit_MultipleTenantsConcurrentBuckets(t *testing.T) {
+	rl := NewRateLimiter(100, 1) // burst=1 per tenant
+	handler := newRateLimitHandler(rl)
+
+	// 50 distinct tenants each send 1 request — all should pass
+	for i := 0; i < 50; i++ {
+		tid := fmt.Sprintf("tenant-%03d", i)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req = req.WithContext(contextWithTenant(tid))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code,
+			"first request for %s should pass", tid)
+	}
+
+	// Second request from each of the first 5 tenants should be rate-limited
+	for i := 0; i < 5; i++ {
+		tid := fmt.Sprintf("tenant-%03d", i)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req = req.WithContext(contextWithTenant(tid))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusTooManyRequests, rec.Code,
+			"second request for %s should be rate-limited", tid)
+	}
+}
+
+// TestRateLimit_GlobalRateLimiter429IsJSON verifies the global rate limiter
+// also returns a well-formed JSON error body on 429.
+func TestRateLimit_GlobalRateLimiter429IsJSON(t *testing.T) {
+	gl := NewGlobalRateLimiter(0.1, 1)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := gl.Middleware(next)
+
+	// Consume the burst
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	// Trigger 429
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	require.Equal(t, http.StatusTooManyRequests, rec2.Code)
+	assert.Equal(t, "application/json", rec2.Header().Get("Content-Type"))
+
+	var errResp map[string]string
+	require.NoError(t, json.NewDecoder(rec2.Body).Decode(&errResp))
+	assert.Equal(t, "global rate limit exceeded", errResp["error"])
 }
 
 func TestGlobalRateLimit_AllowsWithinBurst(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds 6 middleware-level rate limit tests: production config burst/throttle, X-RateLimit headers, 429 JSON body, per-tenant isolation, concurrent tenant buckets, global limiter JSON response
- Adds 6 registration endpoint rate limit tests: per-IP 5/hour limit, IP isolation, global 20/hour cap, Retry-After duration, full HTTP integration 429 test, cross-IP isolation

## Test plan

- [x] 12 new tests across `internal/middleware/ratelimit_test.go` and `internal/api/tenants_test.go`
- [x] `go test ./...` passes (all packages)
- [x] `go build ./...` passes

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)