### PR TITLE
fix(#88): cancel active builds during tenant suspension

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dennisonbertram/agentic-hosting/internal/builds"
 	"github.com/dennisonbertram/agentic-hosting/internal/crypto"
 	"github.com/dennisonbertram/agentic-hosting/internal/databases"
 	"github.com/dennisonbertram/agentic-hosting/internal/db"
@@ -236,6 +237,73 @@ func TestTenantDelete_CleansUpAllManagers(t *testing.T) {
 		"database manager StopAllForTenant should be called with the tenant ID on deletion")
 	assert.Equal(t, []string{"tenant-1"}, kanbanMgr.stopForTenantCalls,
 		"kanban manager StopForTenant should be called with the tenant ID on deletion")
+}
+
+// TestTenantDelete_CancelsActiveBuilds verifies that DELETE /v1/tenant cancels
+// all pending and running builds for the tenant, while leaving completed builds
+// unaffected. This is the fix for GitHub issue #88.
+func TestTenantDelete_CancelsActiveBuilds(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+	token := seedAuthenticatedTenant(t, stateDB, masterKey)
+
+	// Insert a service first
+	_, err := stateDB.Exec(
+		`INSERT INTO services (id, tenant_id, name, status, image, port, created_at, updated_at)
+		 VALUES ('svc-1', 'tenant-1', 'web', 'running', 'nginx:latest', 8080, 10, 20)`,
+	)
+	require.NoError(t, err)
+
+	// Create build manager before inserting builds to avoid reconcileStaleBuilds
+	// marking pending/running builds as failed on startup
+	buildMgr := builds.NewManager(stateDB, apiStubBuilder{}, nil)
+
+	srv := NewServer(ServerConfig{
+		Store:        &db.Store{StateDB: stateDB},
+		MasterKey:    masterKey,
+		DevMode:      true,
+		BuildManager: buildMgr,
+	})
+
+	// Insert builds in various states AFTER manager creation
+	_, err = stateDB.Exec(
+		`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_url, source_ref, image, created_at)
+		 VALUES ('b-pending', 'svc-1', 'tenant-1', 'pending', 'git', 'https://github.com/example/repo', 'main', 'img:1', 10)`,
+	)
+	require.NoError(t, err)
+	_, err = stateDB.Exec(
+		`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_url, source_ref, image, created_at, started_at)
+		 VALUES ('b-running', 'svc-1', 'tenant-1', 'running', 'git', 'https://github.com/example/repo', 'main', 'img:2', 10, 11)`,
+	)
+	require.NoError(t, err)
+	_, err = stateDB.Exec(
+		`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_url, source_ref, image, created_at, started_at, finished_at)
+		 VALUES ('b-done', 'svc-1', 'tenant-1', 'succeeded', 'git', 'https://github.com/example/repo', 'main', 'img:3', 5, 6, 9)`,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/tenant", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+
+	// Active builds should be cancelled
+	var status string
+	err = stateDB.QueryRow(`SELECT status FROM builds WHERE id = 'b-pending'`).Scan(&status)
+	require.NoError(t, err)
+	assert.Equal(t, "cancelled", status, "pending build should be cancelled on tenant suspension")
+
+	err = stateDB.QueryRow(`SELECT status FROM builds WHERE id = 'b-running'`).Scan(&status)
+	require.NoError(t, err)
+	assert.Equal(t, "cancelled", status, "running build should be cancelled on tenant suspension")
+
+	// Completed build should be unaffected
+	err = stateDB.QueryRow(`SELECT status FROM builds WHERE id = 'b-done'`).Scan(&status)
+	require.NoError(t, err)
+	assert.Equal(t, "succeeded", status, "completed build should not be affected by tenant suspension")
 }
 
 // TestServiceRedeploy_CallsRestartAndReturnsService verifies that POST /v1/services/{id}/redeploy

--- a/internal/api/tenants.go
+++ b/internal/api/tenants.go
@@ -395,6 +395,11 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 		s.authInvalidator.InvalidateTenant(tenantID)
 	}
 
+	// Cancel all active builds for this tenant to free build slots
+	if s.buildManager != nil {
+		s.buildManager.CancelAllForTenant(r.Context(), tenantID)
+	}
+
 	// Stop and remove all running containers for this tenant
 	if s.svcManager != nil {
 		s.svcManager.StopAllForTenant(r.Context(), tenantID)

--- a/internal/builds/builds.go
+++ b/internal/builds/builds.go
@@ -501,6 +501,49 @@ func (m *Manager) CancelBuild(ctx context.Context, tenantID, buildID string) err
 	return nil
 }
 
+// CancelAllForTenant cancels all pending and running builds for a tenant.
+// Used during tenant suspension to free build slots and prevent orphaned builds.
+func (m *Manager) CancelAllForTenant(ctx context.Context, tenantID string) error {
+	rows, err := m.db.QueryContext(ctx,
+		`SELECT id FROM builds WHERE tenant_id = ? AND status IN ('pending', 'running')`,
+		tenantID,
+	)
+	if err != nil {
+		return fmt.Errorf("query active builds for tenant %s: %w", tenantID, err)
+	}
+	defer rows.Close()
+
+	var buildIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return fmt.Errorf("scan build id: %w", err)
+		}
+		buildIDs = append(buildIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate active builds: %w", err)
+	}
+
+	now := time.Now().Unix()
+	for _, buildID := range buildIDs {
+		if err := m.builder.CancelBuild(buildID); err != nil {
+			log.Printf("builds: cancel build %s during tenant suspension: %v", buildID, err)
+		}
+		m.db.ExecContext(ctx,
+			`UPDATE builds SET status = 'cancelled', finished_at = ? WHERE id = ? AND status IN ('pending', 'running')`,
+			now, buildID,
+		)
+		m.appendLog(ctx, buildID, "[ah] Build cancelled: tenant suspended")
+		m.closeLogSubs(buildID)
+	}
+
+	if len(buildIDs) > 0 {
+		log.Printf("builds: cancelled %d active builds for suspended tenant %s", len(buildIDs), tenantID)
+	}
+	return nil
+}
+
 // allowedGitHosts is the set of trusted git hosting providers.
 // This prevents DNS rebinding attacks by only allowing known-good hostnames.
 var allowedGitHosts = map[string]bool{

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -86,6 +86,88 @@ func TestStartBuild_MarksFailedWhenDeployFails(t *testing.T) {
 	assert.Contains(t, logs, "Deploy failed: deploy boom")
 }
 
+func TestCancelAllForTenant_CancelsPendingAndRunningBuilds(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	seedBuildTestData(t, stateDB)
+
+	var cancelledIDs []string
+	sb := &stubBuilder{
+		cancelFn: func(buildID string) error {
+			cancelledIDs = append(cancelledIDs, buildID)
+			return nil
+		},
+	}
+
+	// Create manager first so reconcileStaleBuilds runs on an empty builds table
+	mgr := NewManager(stateDB, sb, nil)
+
+	now := time.Now().Unix()
+	// Insert builds in various states AFTER manager creation to avoid reconcileStaleBuilds
+	_, err := stateDB.Exec(
+		`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_url, source_ref, image, created_at)
+		 VALUES (?, ?, ?, 'pending', 'git', 'https://github.com/example/repo', 'main', 'img:1', ?)`,
+		"b-pending", "svc-1", "tenant-1", now,
+	)
+	require.NoError(t, err)
+
+	_, err = stateDB.Exec(
+		`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_url, source_ref, image, created_at, started_at)
+		 VALUES (?, ?, ?, 'running', 'git', 'https://github.com/example/repo', 'main', 'img:2', ?, ?)`,
+		"b-running", "svc-1", "tenant-1", now, now,
+	)
+	require.NoError(t, err)
+
+	_, err = stateDB.Exec(
+		`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_url, source_ref, image, created_at, started_at, finished_at)
+		 VALUES (?, ?, ?, 'succeeded', 'git', 'https://github.com/example/repo', 'main', 'img:3', ?, ?, ?)`,
+		"b-done", "svc-1", "tenant-1", now-100, now-100, now-50,
+	)
+	require.NoError(t, err)
+
+	err = mgr.CancelAllForTenant(context.Background(), "tenant-1")
+	require.NoError(t, err)
+
+	// Pending and running builds should be cancelled
+	assert.Equal(t, "cancelled", getBuildStatus(t, stateDB, "b-pending"))
+	assert.Equal(t, "cancelled", getBuildStatus(t, stateDB, "b-running"))
+
+	// Succeeded build should be unaffected
+	assert.Equal(t, "succeeded", getBuildStatus(t, stateDB, "b-done"))
+
+	// Builder.CancelBuild should have been called for both active builds
+	assert.Len(t, cancelledIDs, 2)
+	assert.Contains(t, cancelledIDs, "b-pending")
+	assert.Contains(t, cancelledIDs, "b-running")
+
+	// Cancelled builds should have suspension log entry
+	var logText string
+	err = stateDB.QueryRow(`SELECT log FROM builds WHERE id = ?`, "b-pending").Scan(&logText)
+	require.NoError(t, err)
+	assert.Contains(t, logText, "tenant suspended")
+}
+
+func TestCancelAllForTenant_NoActiveBuilds_Succeeds(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	seedBuildTestData(t, stateDB)
+
+	now := time.Now().Unix()
+	// Only a completed build exists
+	_, err := stateDB.Exec(
+		`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_url, source_ref, image, created_at, started_at, finished_at)
+		 VALUES (?, ?, ?, 'succeeded', 'git', 'https://github.com/example/repo', 'main', 'img:1', ?, ?, ?)`,
+		"b-done", "svc-1", "tenant-1", now-100, now-100, now-50,
+	)
+	require.NoError(t, err)
+
+	mgr := NewManager(stateDB, &stubBuilder{}, nil)
+
+	err = mgr.CancelAllForTenant(context.Background(), "tenant-1")
+	require.NoError(t, err)
+
+	// Completed build should be unaffected
+	assert.Equal(t, "succeeded", getBuildStatus(t, stateDB, "b-done"))
+}
+
 func seedBuildTestData(t *testing.T, stateDB *sql.DB) {
 	t.Helper()
 	if _, err := stateDB.Exec(


### PR DESCRIPTION
## Summary

- Adds `CancelAllForTenant()` method to builds Manager that cancels queued/running builds
- Wires into `handleTenantDelete` before container stops
- Transitions build status to `cancelled` with suspension log message
- 3 new tests: unit tests for cancellation logic + API integration test

## Test plan

- [x] `TestCancelAllForTenant_CancelsPendingAndRunningBuilds`
- [x] `TestCancelAllForTenant_NoActiveBuilds_Succeeds`
- [x] `TestTenantDelete_CancelsActiveBuilds` (integration)
- [x] `go test ./...` passes

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)