### PR TITLE
fix(#104): add name validation for database names

### DIFF
--- a/internal/databases/databases.go
+++ b/internal/databases/databases.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,6 +19,34 @@ import (
 	"github.com/dennisonbertram/agentic-hosting/internal/diskcheck"
 	"github.com/dennisonbertram/agentic-hosting/internal/docker"
 )
+
+// namePattern matches valid database names: starts with a letter, contains
+// only alphanumeric characters, hyphens, and underscores, and does not end
+// with a hyphen. Length is enforced separately for a clearer error message.
+var namePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]$`)
+
+// ValidateName checks that a database name is safe for use as a Docker
+// container/volume suffix: 1-63 characters, starts with a letter, only
+// alphanumeric plus hyphens/underscores, cannot end with a hyphen.
+func ValidateName(name string) error {
+	if name == "" {
+		return apierr.Validation("database name is required")
+	}
+	if len(name) > 63 {
+		return apierr.Validation("database name must be 63 characters or fewer")
+	}
+	// Single-character names are valid as long as they are a letter.
+	if len(name) == 1 {
+		if name[0] >= 'a' && name[0] <= 'z' || name[0] >= 'A' && name[0] <= 'Z' {
+			return nil
+		}
+		return apierr.Validation("database name must start with a letter and contain only alphanumeric characters, hyphens, and underscores")
+	}
+	if !namePattern.MatchString(name) {
+		return apierr.Validation("database name must start with a letter, contain only alphanumeric characters, hyphens, and underscores, and cannot end with a hyphen")
+	}
+	return nil
+}
 
 // Database represents a provisioned database.
 type Database struct {
@@ -110,8 +139,8 @@ func (m *Manager) Create(ctx context.Context, tenantID string, req CreateRequest
 	if req.Type != "postgres" && req.Type != "redis" {
 		return nil, apierr.Validation(fmt.Sprintf("invalid database type %q; must be \"postgres\" or \"redis\"", req.Type))
 	}
-	if req.Name == "" || len(req.Name) > 128 {
-		return nil, apierr.Validation("name is required (max 128 chars)")
+	if err := ValidateName(req.Name); err != nil {
+		return nil, err
 	}
 
 	// Check disk space before provisioning

--- a/internal/databases/databases_test.go
+++ b/internal/databases/databases_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"net"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -329,6 +330,56 @@ func TestDelete_WipesVolumeBeforeRemoval(t *testing.T) {
 		"WipeVolume must be called before RemoveVolume")
 	assert.Equal(t, expectedVolume, wipeVolume,
 		"WipeVolume must receive the database's volume name")
+}
+
+// ---------------------------------------------------------------------------
+// Name validation tests
+// ---------------------------------------------------------------------------
+
+func TestValidateName_ValidNames(t *testing.T) {
+	valid := []string{
+		"mydb",
+		"my-db-1",
+		"postgres_main",
+		"a",              // single letter
+		"A",              // single uppercase letter
+		"db1",            // letter then digits
+		"my_db",          // underscores
+		"My-Mixed_Case1", // mixed case with hyphens and underscores
+		strings.Repeat("a", 63), // max length
+	}
+	for _, name := range valid {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateName(name)
+			assert.NoError(t, err, "expected name %q to be valid", name)
+		})
+	}
+}
+
+func TestValidateName_InvalidNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		display string // test sub-name for readability
+	}{
+		{"", "empty"},
+		{"1starts-with-number", "starts_with_number"},
+		{"has spaces", "has_spaces"},
+		{strings.Repeat("a", 64), "too_long_64_chars"},
+		{"special!chars", "special_chars"},
+		{"-starts-with-hyphen", "starts_with_hyphen"},
+		{"_starts-with-underscore", "starts_with_underscore"},
+		{"ends-with-hyphen-", "ends_with_hyphen"},
+		{"name.with.dots", "has_dots"},
+		{"name@domain", "has_at_sign"},
+		{"name with\ttab", "has_tab"},
+		{"1", "single_digit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.display, func(t *testing.T) {
+			err := ValidateName(tt.name)
+			assert.Error(t, err, "expected name %q to be invalid", tt.name)
+		})
+	}
 }
 
 func seedDatabaseTestData(t *testing.T, stateDB *sql.DB, maxDatabases int) {


### PR DESCRIPTION
## Summary
- Validates database names: 1-63 chars, starts with letter, alphanumeric + hyphens/underscores
- Returns 400 for invalid names instead of allowing Docker-incompatible names
- 21 test cases (9 valid + 12 invalid)

## Test plan
- [x] `TestValidateName_ValidNames` — 9 cases
- [x] `TestValidateName_InvalidNames` — 12 cases
- [x] `go test ./...` passes
Closes #104
🤖 Generated with [Claude Code](https://claude.com/claude-code)