### PR TITLE
feat(#105): Docker storage usage in detailed health endpoint

### DIFF
--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"log"
 	"math"
 	"net/http"
 	"os/exec"
@@ -18,10 +19,12 @@ type HealthResponse struct {
 }
 
 type DetailedHealthResponse struct {
-	Status string     `json:"status"`
-	Docker DockerInfo `json:"docker"`
-	GVisor GVisorInfo `json:"gvisor"`
-	Disk   DiskInfo   `json:"disk"`
+	Status        string             `json:"status"`
+	Docker        DockerInfo         `json:"docker"`
+	GVisor        GVisorInfo         `json:"gvisor"`
+	Disk          DiskInfo           `json:"disk"`
+	DockerDisk    DiskInfo           `json:"docker_disk"`
+	DockerStorage *DockerStorageInfo `json:"docker_storage,omitempty"`
 }
 
 type DockerInfo struct {
@@ -38,6 +41,15 @@ type DiskInfo struct {
 	TotalGB     float64 `json:"total_gb"`
 	FreeGB      float64 `json:"free_gb"`
 	UsedPercent float64 `json:"used_percent"`
+}
+
+// DockerStorageInfo holds Docker object storage sizes from the Docker system df API.
+type DockerStorageInfo struct {
+	ImagesSizeBytes     int64   `json:"images_size_bytes"`
+	ContainersSizeBytes int64   `json:"containers_size_bytes"`
+	VolumesSizeBytes    int64   `json:"volumes_size_bytes"`
+	BuildCacheSizeBytes int64   `json:"build_cache_size_bytes"`
+	TotalSizeGB         float64 `json:"total_size_gb"`
 }
 
 var (
@@ -111,31 +123,65 @@ func (s *Server) buildDetailedHealth() DetailedHealthResponse {
 		resp.GVisor = GVisorInfo{Available: version != "", Version: version}
 	}
 
-	// Check disk (no exec, safe syscall)
+	// Check disk for /var/lib/ah (no exec, safe syscall)
 	var stat syscall.Statfs_t
 	if err := syscall.Statfs("/var/lib/ah", &stat); err == nil {
-		totalBytes := stat.Blocks * uint64(stat.Bsize)
-		freeBytes := stat.Bavail * uint64(stat.Bsize)
-		totalGB := float64(totalBytes) / (1024 * 1024 * 1024)
-		freeGB := float64(freeBytes) / (1024 * 1024 * 1024)
-		usedPercent := 0.0
-		if totalGB > 0 {
-			usedPercent = ((totalGB - freeGB) / totalGB) * 100
-		}
-		resp.Disk = DiskInfo{
-			TotalGB:     round2(totalGB),
-			FreeGB:      round2(freeGB),
-			UsedPercent: round2(usedPercent),
+		resp.Disk = statfsToDiskInfo(stat)
+	}
+
+	// Check disk for /var/lib/docker (separate partition may fill independently)
+	var dockerStat syscall.Statfs_t
+	if err := syscall.Statfs("/var/lib/docker", &dockerStat); err == nil {
+		resp.DockerDisk = statfsToDiskInfo(dockerStat)
+	}
+
+	// Fetch Docker object-level storage usage via the Docker API
+	if s.dockerClient != nil {
+		ctx3, cancel3 := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel3()
+		if du, err := s.dockerClient.DiskUsage(ctx3); err == nil {
+			totalBytes := du.ImagesSize + du.ContainersSize + du.VolumesSize + du.BuildCacheSize
+			resp.DockerStorage = &DockerStorageInfo{
+				ImagesSizeBytes:     du.ImagesSize,
+				ContainersSizeBytes: du.ContainersSize,
+				VolumesSizeBytes:    du.VolumesSize,
+				BuildCacheSizeBytes: du.BuildCacheSize,
+				TotalSizeGB:         round2(float64(totalBytes) / (1024 * 1024 * 1024)),
+			}
+		} else {
+			log.Printf("WARNING: failed to fetch Docker disk usage: %v", err)
 		}
 	}
 
+	// Degrade status if database is unreachable
 	if s.store == nil || s.store.StateDB == nil {
 		resp.Status = "degraded"
 	} else if err := s.store.StateDB.Ping(); err != nil {
 		resp.Status = "degraded"
 	}
 
+	// Degrade status if either disk path is critically full (>90% used)
+	if resp.Disk.UsedPercent > 90 || resp.DockerDisk.UsedPercent > 90 {
+		resp.Status = "degraded"
+	}
+
 	return resp
+}
+
+func statfsToDiskInfo(stat syscall.Statfs_t) DiskInfo {
+	totalBytes := stat.Blocks * uint64(stat.Bsize)
+	freeBytes := stat.Bavail * uint64(stat.Bsize)
+	totalGB := float64(totalBytes) / (1024 * 1024 * 1024)
+	freeGB := float64(freeBytes) / (1024 * 1024 * 1024)
+	usedPercent := 0.0
+	if totalGB > 0 {
+		usedPercent = ((totalGB - freeGB) / totalGB) * 100
+	}
+	return DiskInfo{
+		TotalGB:     round2(totalGB),
+		FreeGB:      round2(freeGB),
+		UsedPercent: round2(usedPercent),
+	}
 }
 
 func round2(f float64) float64 {

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -1,0 +1,222 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dennisonbertram/agentic-hosting/internal/db"
+	"github.com/dennisonbertram/agentic-hosting/internal/docker"
+	"github.com/dennisonbertram/agentic-hosting/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetailedHealth_IncludesDockerStorage(t *testing.T) {
+	// Reset cache so previous test runs don't leak into this one.
+	detailedHealthCacheMu.Lock()
+	detailedHealthCacheValid = false
+	detailedHealthCacheMu.Unlock()
+
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+	token := seedAuthenticatedTenant(t, stateDB, masterKey)
+
+	mockDocker := &testutil.MockDockerClient{
+		DiskUsageFn: func(ctx context.Context) (*docker.StorageUsage, error) {
+			return &docker.StorageUsage{
+				ImagesSize:     1024 * 1024 * 1024 * 2, // 2 GB
+				ContainersSize: 1024 * 1024 * 500,      // 500 MB
+				VolumesSize:    1024 * 1024 * 1024,      // 1 GB
+				BuildCacheSize: 1024 * 1024 * 256,       // 256 MB
+			}, nil
+		},
+	}
+
+	srv := NewServer(ServerConfig{
+		Store:     &db.Store{StateDB: stateDB},
+		MasterKey: masterKey,
+		DevMode:   true,
+		Docker:    mockDocker,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/system/health/detailed", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "unexpected body: %s", rr.Body.String())
+
+	var resp DetailedHealthResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	require.NotNil(t, resp.DockerStorage, "docker_storage should be present in response")
+	assert.Equal(t, int64(1024*1024*1024*2), resp.DockerStorage.ImagesSizeBytes, "images_size_bytes")
+	assert.Equal(t, int64(1024*1024*500), resp.DockerStorage.ContainersSizeBytes, "containers_size_bytes")
+	assert.Equal(t, int64(1024*1024*1024), resp.DockerStorage.VolumesSizeBytes, "volumes_size_bytes")
+	assert.Equal(t, int64(1024*1024*256), resp.DockerStorage.BuildCacheSizeBytes, "build_cache_size_bytes")
+	assert.Greater(t, resp.DockerStorage.TotalSizeGB, 0.0, "total_size_gb should be positive")
+	assert.Equal(t, 1, mockDocker.DiskUsageCalls, "DiskUsage should have been called once")
+}
+
+func TestDetailedHealth_DockerStorageError_OmitsField(t *testing.T) {
+	// Reset cache.
+	detailedHealthCacheMu.Lock()
+	detailedHealthCacheValid = false
+	detailedHealthCacheMu.Unlock()
+
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+	token := seedAuthenticatedTenant(t, stateDB, masterKey)
+
+	mockDocker := &testutil.MockDockerClient{
+		DiskUsageFn: func(ctx context.Context) (*docker.StorageUsage, error) {
+			return nil, fmt.Errorf("docker not reachable")
+		},
+	}
+
+	srv := NewServer(ServerConfig{
+		Store:     &db.Store{StateDB: stateDB},
+		MasterKey: masterKey,
+		DevMode:   true,
+		Docker:    mockDocker,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/system/health/detailed", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	_, hasDockerStorage := resp["docker_storage"]
+	assert.False(t, hasDockerStorage, "docker_storage should be omitted on error (omitempty)")
+}
+
+func TestDetailedHealth_NoDockerClient_OmitsDockerStorage(t *testing.T) {
+	// Reset cache.
+	detailedHealthCacheMu.Lock()
+	detailedHealthCacheValid = false
+	detailedHealthCacheMu.Unlock()
+
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+	token := seedAuthenticatedTenant(t, stateDB, masterKey)
+
+	// No Docker client passed.
+	srv := NewServer(ServerConfig{
+		Store:     &db.Store{StateDB: stateDB},
+		MasterKey: masterKey,
+		DevMode:   true,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/system/health/detailed", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	_, hasDockerStorage := resp["docker_storage"]
+	assert.False(t, hasDockerStorage, "docker_storage should be omitted when no Docker client")
+}
+
+func TestDetailedHealth_ResponseIncludesDockerDisk(t *testing.T) {
+	// Reset cache.
+	detailedHealthCacheMu.Lock()
+	detailedHealthCacheValid = false
+	detailedHealthCacheMu.Unlock()
+
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+	token := seedAuthenticatedTenant(t, stateDB, masterKey)
+
+	srv := NewServer(ServerConfig{
+		Store:     &db.Store{StateDB: stateDB},
+		MasterKey: masterKey,
+		DevMode:   true,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/system/health/detailed", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	// docker_disk should be present in the response even if /var/lib/docker doesn't
+	// exist (it will be zeroed). The key point is the JSON field is emitted.
+	_, hasDockerDisk := resp["docker_disk"]
+	assert.True(t, hasDockerDisk, "docker_disk field should always be present in response")
+}
+
+func TestDetailedHealth_CacheBypass(t *testing.T) {
+	// Make sure cache is warm.
+	detailedHealthCacheMu.Lock()
+	detailedHealthCacheValid = true
+	detailedHealthCacheTime = time.Now()
+	detailedHealthCache = DetailedHealthResponse{
+		Status: "ok",
+		Docker: DockerInfo{Available: false},
+	}
+	detailedHealthCacheMu.Unlock()
+
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+	token := seedAuthenticatedTenant(t, stateDB, masterKey)
+
+	callCount := 0
+	mockDocker := &testutil.MockDockerClient{
+		DiskUsageFn: func(ctx context.Context) (*docker.StorageUsage, error) {
+			callCount++
+			return &docker.StorageUsage{ImagesSize: 42}, nil
+		},
+	}
+
+	srv := NewServer(ServerConfig{
+		Store:     &db.Store{StateDB: stateDB},
+		MasterKey: masterKey,
+		DevMode:   true,
+		Docker:    mockDocker,
+	})
+
+	// First request should serve from cache (DiskUsage not called).
+	req1 := httptest.NewRequest(http.MethodGet, "/v1/system/health/detailed", nil)
+	req1.Header.Set("Authorization", "Bearer "+token)
+	rr1 := httptest.NewRecorder()
+	srv.ServeHTTP(rr1, req1)
+	require.Equal(t, http.StatusOK, rr1.Code)
+	assert.Equal(t, 0, callCount, "cached response should not call DiskUsage")
+}
+
+func TestStatfsToDiskInfo(t *testing.T) {
+	// Unit test the helper with known values.
+	di := statfsToDiskInfo(makeFakeStatfs(100*1024*1024*1024, 20*1024*1024*1024))
+	assert.InDelta(t, 100.0, di.TotalGB, 0.1, "total_gb should be ~100")
+	assert.InDelta(t, 20.0, di.FreeGB, 0.1, "free_gb should be ~20")
+	assert.InDelta(t, 80.0, di.UsedPercent, 0.1, "used_percent should be ~80")
+}
+
+func TestStatfsToDiskInfo_ZeroTotal(t *testing.T) {
+	di := statfsToDiskInfo(makeFakeStatfs(0, 0))
+	assert.Equal(t, 0.0, di.TotalGB)
+	assert.Equal(t, 0.0, di.FreeGB)
+	assert.Equal(t, 0.0, di.UsedPercent, "zero total should yield 0% used, not NaN")
+}

--- a/internal/api/health_test_helpers_darwin.go
+++ b/internal/api/health_test_helpers_darwin.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+package api
+
+import "syscall"
+
+// makeFakeStatfs constructs a Statfs_t for unit tests with the given total
+// and free byte counts. Block size is fixed at 4096.
+func makeFakeStatfs(totalBytes, freeBytes uint64) syscall.Statfs_t {
+	const bsize = 4096
+	return syscall.Statfs_t{
+		Bsize:  uint32(bsize),
+		Blocks: totalBytes / bsize,
+		Bavail: freeBytes / bsize,
+	}
+}

--- a/internal/api/health_test_helpers_linux.go
+++ b/internal/api/health_test_helpers_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package api
+
+import "syscall"
+
+// makeFakeStatfs constructs a Statfs_t for unit tests with the given total
+// and free byte counts. Block size is fixed at 4096.
+func makeFakeStatfs(totalBytes, freeBytes uint64) syscall.Statfs_t {
+	const bsize = 4096
+	return syscall.Statfs_t{
+		Bsize:  int64(bsize),
+		Blocks: totalBytes / bsize,
+		Bavail: freeBytes / bsize,
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -70,6 +70,7 @@ type Server struct {
 	buildManager      *builds.Manager
 	dbManager         databaseManager
 	kanbanManager     kanbanManager
+	dockerClient      docker.Client
 	authRateLimiter   *middleware.RateLimiter
 	globalRateLimiter *middleware.GlobalRateLimiter
 	idempotencyStore  *middleware.IdempotencyStore
@@ -107,6 +108,7 @@ func NewServer(cfg ServerConfig) *Server {
 		buildManager:      cfg.BuildManager,
 		dbManager:         cfg.DatabaseManager,
 		kanbanManager:     cfg.KanbanManager,
+		dockerClient:      cfg.Docker,
 		authRateLimiter:   rl,
 		globalRateLimiter: globalRL,
 		idempotencyStore:  idem,

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
@@ -45,6 +46,15 @@ type Client interface {
 	StopAndRemoveByName(ctx context.Context, name string) error
 	PruneDanglingImages(ctx context.Context) (int, error)
 	ListVolumes(ctx context.Context, prefix string) ([]string, error)
+	DiskUsage(ctx context.Context) (*StorageUsage, error)
+}
+
+// StorageUsage holds aggregate Docker storage consumption broken down by type.
+type StorageUsage struct {
+	ImagesSize     int64 `json:"images_size_bytes"`
+	ContainersSize int64 `json:"containers_size_bytes"`
+	VolumesSize    int64 `json:"volumes_size_bytes"`
+	BuildCacheSize int64 `json:"build_cache_size_bytes"`
 }
 
 // Compile-time check: DockerClient must satisfy Client.
@@ -575,6 +585,40 @@ func (c *DockerClient) PruneDanglingImages(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("prune images: %w", err)
 	}
 	return len(report.ImagesDeleted), nil
+}
+
+// DiskUsage returns aggregate Docker storage consumption by category.
+// Calls the Docker Engine /system/df API.
+func (c *DockerClient) DiskUsage(ctx context.Context) (*StorageUsage, error) {
+	du, err := c.cli.DiskUsage(ctx, types.DiskUsageOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("docker disk usage: %w", err)
+	}
+
+	usage := &StorageUsage{}
+
+	for _, img := range du.Images {
+		if img != nil {
+			usage.ImagesSize += img.Size
+		}
+	}
+	for _, ctr := range du.Containers {
+		if ctr != nil {
+			usage.ContainersSize += ctr.SizeRw
+		}
+	}
+	for _, vol := range du.Volumes {
+		if vol != nil && vol.UsageData != nil {
+			usage.VolumesSize += vol.UsageData.Size
+		}
+	}
+	for _, bc := range du.BuildCache {
+		if bc != nil {
+			usage.BuildCacheSize += bc.Size
+		}
+	}
+
+	return usage, nil
 }
 
 // ListVolumes returns volume names matching the given prefix.

--- a/internal/testutil/docker_mock.go
+++ b/internal/testutil/docker_mock.go
@@ -102,6 +102,10 @@ type MockDockerClient struct {
 	// ListVolumes
 	ListVolumesFn    func(ctx context.Context, prefix string) ([]string, error)
 	ListVolumesCalls []string // prefixes queried
+
+	// DiskUsage
+	DiskUsageFn    func(ctx context.Context) (*docker.StorageUsage, error)
+	DiskUsageCalls int
 }
 
 // Ensure MockDockerClient satisfies the docker.Client interface at compile time.
@@ -289,4 +293,12 @@ func (m *MockDockerClient) ListVolumes(ctx context.Context, prefix string) ([]st
 		return m.ListVolumesFn(ctx, prefix)
 	}
 	return nil, nil
+}
+
+func (m *MockDockerClient) DiskUsage(ctx context.Context) (*docker.StorageUsage, error) {
+	m.DiskUsageCalls++
+	if m.DiskUsageFn != nil {
+		return m.DiskUsageFn(ctx)
+	}
+	return &docker.StorageUsage{}, nil
 }


### PR DESCRIPTION
## Summary
- Adds `docker_disk` and `docker_storage` fields to detailed health response
- Reports Docker images, containers, volumes, and build cache sizes
- Adds DiskUsage method to Docker client interface
- Degrades health status to "degraded" if Docker disk > 90%
- 7 new tests

## Test plan
- [x] `TestHealthDetailed_*` — 7 tests covering storage data, errors, cache bypass
- [x] `go test ./...` passes
Closes #105
🤖 Generated with [Claude Code](https://claude.com/claude-code)