### PR TITLE
feat(#89): add filtering to activity endpoint

### DIFF
--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -21,13 +21,25 @@ type ActivityEvent struct {
 	Status       string `json:"status,omitempty"`
 	Message      string `json:"message"`
 	CreatedAt    int64  `json:"created_at"`
+	ServiceID    string `json:"service_id,omitempty"`
+}
+
+// activityFilter holds optional query parameters for filtering activity events.
+// All fields are AND-combined. Zero values mean "no filter".
+type activityFilter struct {
+	ResourceType string // e.g. "service", "build", "database", "api_key", "tenant"
+	Action       string // e.g. "service.created", "build.failed"
+	ServiceID    string // filter to events for a specific service
+	Since        int64  // only events with created_at >= Since
+	Offset       int    // skip this many events (after sort) for pagination
 }
 
 func (s *Server) handleActivityList(w http.ResponseWriter, r *http.Request) {
 	tenantID := middleware.GetTenantID(r.Context())
+	q := r.URL.Query()
 
 	limit := 50
-	if raw := r.URL.Query().Get("limit"); raw != "" {
+	if raw := q.Get("limit"); raw != "" {
 		value, err := strconv.Atoi(raw)
 		if err != nil || value < 1 || value > 200 {
 			writeError(w, http.StatusBadRequest, "limit must be between 1 and 200")
@@ -36,7 +48,30 @@ func (s *Server) handleActivityList(w http.ResponseWriter, r *http.Request) {
 		limit = value
 	}
 
-	events, err := s.listActivityEvents(r.Context(), tenantID, limit)
+	var filter activityFilter
+	filter.ResourceType = q.Get("resource_type")
+	filter.Action = q.Get("action")
+	filter.ServiceID = q.Get("service_id")
+
+	if raw := q.Get("since"); raw != "" {
+		value, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || value < 0 {
+			writeError(w, http.StatusBadRequest, "since must be a non-negative unix timestamp")
+			return
+		}
+		filter.Since = value
+	}
+
+	if raw := q.Get("offset"); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value < 0 {
+			writeError(w, http.StatusBadRequest, "offset must be a non-negative integer")
+			return
+		}
+		filter.Offset = value
+	}
+
+	events, err := s.listActivityEvents(r.Context(), tenantID, limit, filter)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list activity")
 		return
@@ -44,23 +79,60 @@ func (s *Server) handleActivityList(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, events)
 }
 
-func (s *Server) listActivityEvents(ctx context.Context, tenantID string, limit int) ([]ActivityEvent, error) {
+func (s *Server) listActivityEvents(ctx context.Context, tenantID string, limit int, filter activityFilter) ([]ActivityEvent, error) {
 	events := make([]ActivityEvent, 0, limit)
 
-	if err := s.appendTenantEvents(ctx, tenantID, &events); err != nil {
-		return nil, err
+	// When resource_type is set, only query the relevant table(s).
+	// service_id implies resource_type is either "service" or "build" (builds belong to services).
+	wantType := func(rt string) bool {
+		if filter.ResourceType == "" && filter.ServiceID == "" {
+			return true
+		}
+		if filter.ResourceType != "" && filter.ResourceType != rt {
+			return false
+		}
+		// If service_id is set but no resource_type, only service and build are relevant.
+		if filter.ServiceID != "" && filter.ResourceType == "" {
+			return rt == "service" || rt == "build"
+		}
+		return true
 	}
-	if err := s.appendServiceEvents(ctx, tenantID, &events); err != nil {
-		return nil, err
+
+	if wantType("tenant") {
+		if err := s.appendTenantEvents(ctx, tenantID, &events, filter); err != nil {
+			return nil, err
+		}
 	}
-	if err := s.appendBuildEvents(ctx, tenantID, &events); err != nil {
-		return nil, err
+	if wantType("service") {
+		if err := s.appendServiceEvents(ctx, tenantID, &events, filter); err != nil {
+			return nil, err
+		}
 	}
-	if err := s.appendDatabaseEvents(ctx, tenantID, &events); err != nil {
-		return nil, err
+	if wantType("build") {
+		if err := s.appendBuildEvents(ctx, tenantID, &events, filter); err != nil {
+			return nil, err
+		}
 	}
-	if err := s.appendAPIKeyEvents(ctx, tenantID, &events); err != nil {
-		return nil, err
+	if wantType("database") {
+		if err := s.appendDatabaseEvents(ctx, tenantID, &events, filter); err != nil {
+			return nil, err
+		}
+	}
+	if wantType("api_key") {
+		if err := s.appendAPIKeyEvents(ctx, tenantID, &events, filter); err != nil {
+			return nil, err
+		}
+	}
+
+	// Post-filter by action if specified (actions are computed in Go, not SQL).
+	if filter.Action != "" {
+		filtered := events[:0]
+		for _, e := range events {
+			if e.Action == filter.Action {
+				filtered = append(filtered, e)
+			}
+		}
+		events = filtered
 	}
 
 	sort.Slice(events, func(i, j int) bool {
@@ -69,13 +141,27 @@ func (s *Server) listActivityEvents(ctx context.Context, tenantID string, limit 
 		}
 		return events[i].CreatedAt > events[j].CreatedAt
 	})
+
+	// Apply offset for pagination.
+	if filter.Offset > 0 {
+		if filter.Offset >= len(events) {
+			return []ActivityEvent{}, nil
+		}
+		events = events[filter.Offset:]
+	}
+
 	if len(events) > limit {
 		events = events[:limit]
 	}
 	return events, nil
 }
 
-func (s *Server) appendTenantEvents(ctx context.Context, tenantID string, events *[]ActivityEvent) error {
+func (s *Server) appendTenantEvents(ctx context.Context, tenantID string, events *[]ActivityEvent, filter activityFilter) error {
+	// service_id filter does not apply to tenant events; skip them.
+	if filter.ServiceID != "" {
+		return nil
+	}
+
 	var id, name, status string
 	var createdAt, updatedAt int64
 	err := s.store.StateDB.QueryRowContext(ctx,
@@ -89,17 +175,19 @@ func (s *Server) appendTenantEvents(ctx context.Context, tenantID string, events
 		return fmt.Errorf("tenant activity: %w", err)
 	}
 
-	*events = append(*events, ActivityEvent{
-		ID:           fmt.Sprintf("tenant-created-%s-%d", id, createdAt),
-		ResourceType: "tenant",
-		ResourceID:   id,
-		ResourceName: name,
-		Action:       "tenant.created",
-		Status:       status,
-		Message:      fmt.Sprintf("Tenant %s was created", name),
-		CreatedAt:    createdAt,
-	})
-	if updatedAt > createdAt {
+	if filter.Since == 0 || createdAt >= filter.Since {
+		*events = append(*events, ActivityEvent{
+			ID:           fmt.Sprintf("tenant-created-%s-%d", id, createdAt),
+			ResourceType: "tenant",
+			ResourceID:   id,
+			ResourceName: name,
+			Action:       "tenant.created",
+			Status:       status,
+			Message:      fmt.Sprintf("Tenant %s was created", name),
+			CreatedAt:    createdAt,
+		})
+	}
+	if updatedAt > createdAt && (filter.Since == 0 || updatedAt >= filter.Since) {
 		action := "tenant.updated"
 		message := fmt.Sprintf("Tenant %s was updated", name)
 		if status != "active" {
@@ -120,13 +208,18 @@ func (s *Server) appendTenantEvents(ctx context.Context, tenantID string, events
 	return nil
 }
 
-func (s *Server) appendServiceEvents(ctx context.Context, tenantID string, events *[]ActivityEvent) error {
-	rows, err := s.store.StateDB.QueryContext(ctx,
-		`SELECT id, name, status, COALESCE(last_error, ''), circuit_open, created_at, updated_at
+func (s *Server) appendServiceEvents(ctx context.Context, tenantID string, events *[]ActivityEvent, filter activityFilter) error {
+	query := `SELECT id, name, status, COALESCE(last_error, ''), circuit_open, created_at, updated_at
 		 FROM services
-		 WHERE tenant_id = ?`,
-		tenantID,
-	)
+		 WHERE tenant_id = ?`
+	args := []any{tenantID}
+
+	if filter.ServiceID != "" {
+		query += ` AND id = ?`
+		args = append(args, filter.ServiceID)
+	}
+
+	rows, err := s.store.StateDB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("service activity: %w", err)
 	}
@@ -140,18 +233,21 @@ func (s *Server) appendServiceEvents(ctx context.Context, tenantID string, event
 			return fmt.Errorf("scan service activity: %w", err)
 		}
 
-		*events = append(*events, ActivityEvent{
-			ID:           fmt.Sprintf("service-created-%s-%d", id, createdAt),
-			ResourceType: "service",
-			ResourceID:   id,
-			ResourceName: name,
-			Action:       "service.created",
-			Status:       status,
-			Message:      fmt.Sprintf("Service %s was created", name),
-			CreatedAt:    createdAt,
-		})
+		if filter.Since == 0 || createdAt >= filter.Since {
+			*events = append(*events, ActivityEvent{
+				ID:           fmt.Sprintf("service-created-%s-%d", id, createdAt),
+				ResourceType: "service",
+				ResourceID:   id,
+				ResourceName: name,
+				Action:       "service.created",
+				Status:       status,
+				Message:      fmt.Sprintf("Service %s was created", name),
+				CreatedAt:    createdAt,
+				ServiceID:    id,
+			})
+		}
 
-		if updatedAt > createdAt {
+		if updatedAt > createdAt && (filter.Since == 0 || updatedAt >= filter.Since) {
 			action := "service.updated"
 			message := fmt.Sprintf("Service %s changed state to %s", name, status)
 			switch {
@@ -180,21 +276,27 @@ func (s *Server) appendServiceEvents(ctx context.Context, tenantID string, event
 				Status:       status,
 				Message:      message,
 				CreatedAt:    updatedAt,
+				ServiceID:    id,
 			})
 		}
 	}
 	return rows.Err()
 }
 
-func (s *Server) appendBuildEvents(ctx context.Context, tenantID string, events *[]ActivityEvent) error {
-	rows, err := s.store.StateDB.QueryContext(ctx,
-		`SELECT b.id, b.service_id, COALESCE(s.name, ''), b.status, COALESCE(b.source_ref, ''), COALESCE(b.source_url, ''),
+func (s *Server) appendBuildEvents(ctx context.Context, tenantID string, events *[]ActivityEvent, filter activityFilter) error {
+	query := `SELECT b.id, b.service_id, COALESCE(s.name, ''), b.status, COALESCE(b.source_ref, ''), COALESCE(b.source_url, ''),
 		        b.created_at, b.started_at, b.finished_at
 		 FROM builds b
 		 LEFT JOIN services s ON s.id = b.service_id
-		 WHERE b.tenant_id = ?`,
-		tenantID,
-	)
+		 WHERE b.tenant_id = ?`
+	args := []any{tenantID}
+
+	if filter.ServiceID != "" {
+		query += ` AND b.service_id = ?`
+		args = append(args, filter.ServiceID)
+	}
+
+	rows, err := s.store.StateDB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("build activity: %w", err)
 	}
@@ -213,18 +315,21 @@ func (s *Server) appendBuildEvents(ctx context.Context, tenantID string, events 
 			refSuffix = fmt.Sprintf(" from %s", sourceRef)
 		}
 
-		*events = append(*events, ActivityEvent{
-			ID:           fmt.Sprintf("build-created-%s-%d", id, createdAt),
-			ResourceType: "build",
-			ResourceID:   id,
-			ResourceName: serviceName,
-			Action:       "build.queued",
-			Status:       status,
-			Message:      fmt.Sprintf("Build queued for %s%s", defaultName(serviceName, serviceID), refSuffix),
-			CreatedAt:    createdAt,
-		})
+		if filter.Since == 0 || createdAt >= filter.Since {
+			*events = append(*events, ActivityEvent{
+				ID:           fmt.Sprintf("build-created-%s-%d", id, createdAt),
+				ResourceType: "build",
+				ResourceID:   id,
+				ResourceName: serviceName,
+				Action:       "build.queued",
+				Status:       status,
+				Message:      fmt.Sprintf("Build queued for %s%s", defaultName(serviceName, serviceID), refSuffix),
+				CreatedAt:    createdAt,
+				ServiceID:    serviceID,
+			})
+		}
 
-		if startedAt.Valid {
+		if startedAt.Valid && (filter.Since == 0 || startedAt.Int64 >= filter.Since) {
 			*events = append(*events, ActivityEvent{
 				ID:           fmt.Sprintf("build-started-%s-%d", id, startedAt.Int64),
 				ResourceType: "build",
@@ -234,10 +339,11 @@ func (s *Server) appendBuildEvents(ctx context.Context, tenantID string, events 
 				Status:       status,
 				Message:      fmt.Sprintf("Build started for %s", defaultName(serviceName, serviceID)),
 				CreatedAt:    startedAt.Int64,
+				ServiceID:    serviceID,
 			})
 		}
 
-		if finishedAt.Valid {
+		if finishedAt.Valid && (filter.Since == 0 || finishedAt.Int64 >= filter.Since) {
 			action := "build.finished"
 			message := fmt.Sprintf("Build finished for %s", defaultName(serviceName, serviceID))
 			if status == "succeeded" {
@@ -259,13 +365,19 @@ func (s *Server) appendBuildEvents(ctx context.Context, tenantID string, events 
 				Status:       status,
 				Message:      message,
 				CreatedAt:    finishedAt.Int64,
+				ServiceID:    serviceID,
 			})
 		}
 	}
 	return rows.Err()
 }
 
-func (s *Server) appendDatabaseEvents(ctx context.Context, tenantID string, events *[]ActivityEvent) error {
+func (s *Server) appendDatabaseEvents(ctx context.Context, tenantID string, events *[]ActivityEvent, filter activityFilter) error {
+	// service_id filter does not apply to database events; skip them.
+	if filter.ServiceID != "" {
+		return nil
+	}
+
 	rows, err := s.store.StateDB.QueryContext(ctx,
 		`SELECT id, name, type, status, created_at, updated_at
 		 FROM databases
@@ -284,18 +396,20 @@ func (s *Server) appendDatabaseEvents(ctx context.Context, tenantID string, even
 			return fmt.Errorf("scan database activity: %w", err)
 		}
 
-		*events = append(*events, ActivityEvent{
-			ID:           fmt.Sprintf("database-created-%s-%d", id, createdAt),
-			ResourceType: "database",
-			ResourceID:   id,
-			ResourceName: name,
-			Action:       "database.created",
-			Status:       status,
-			Message:      fmt.Sprintf("%s database %s provisioning started", titleCase(dbType), name),
-			CreatedAt:    createdAt,
-		})
+		if filter.Since == 0 || createdAt >= filter.Since {
+			*events = append(*events, ActivityEvent{
+				ID:           fmt.Sprintf("database-created-%s-%d", id, createdAt),
+				ResourceType: "database",
+				ResourceID:   id,
+				ResourceName: name,
+				Action:       "database.created",
+				Status:       status,
+				Message:      fmt.Sprintf("%s database %s provisioning started", titleCase(dbType), name),
+				CreatedAt:    createdAt,
+			})
+		}
 
-		if updatedAt > createdAt {
+		if updatedAt > createdAt && (filter.Since == 0 || updatedAt >= filter.Since) {
 			action := "database.updated"
 			message := fmt.Sprintf("Database %s changed state to %s", name, status)
 			if status == "ready" {
@@ -320,7 +434,12 @@ func (s *Server) appendDatabaseEvents(ctx context.Context, tenantID string, even
 	return rows.Err()
 }
 
-func (s *Server) appendAPIKeyEvents(ctx context.Context, tenantID string, events *[]ActivityEvent) error {
+func (s *Server) appendAPIKeyEvents(ctx context.Context, tenantID string, events *[]ActivityEvent, filter activityFilter) error {
+	// service_id filter does not apply to API key events; skip them.
+	if filter.ServiceID != "" {
+		return nil
+	}
+
 	rows, err := s.store.StateDB.QueryContext(ctx,
 		`SELECT id, name, created_at, revoked_at
 		 FROM api_keys
@@ -340,16 +459,18 @@ func (s *Server) appendAPIKeyEvents(ctx context.Context, tenantID string, events
 			return fmt.Errorf("scan api key activity: %w", err)
 		}
 
-		*events = append(*events, ActivityEvent{
-			ID:           fmt.Sprintf("api-key-created-%s-%d", id, createdAt),
-			ResourceType: "api_key",
-			ResourceID:   id,
-			ResourceName: name,
-			Action:       "api_key.created",
-			Message:      fmt.Sprintf("API key %s was created", name),
-			CreatedAt:    createdAt,
-		})
-		if revokedAt.Valid {
+		if filter.Since == 0 || createdAt >= filter.Since {
+			*events = append(*events, ActivityEvent{
+				ID:           fmt.Sprintf("api-key-created-%s-%d", id, createdAt),
+				ResourceType: "api_key",
+				ResourceID:   id,
+				ResourceName: name,
+				Action:       "api_key.created",
+				Message:      fmt.Sprintf("API key %s was created", name),
+				CreatedAt:    createdAt,
+			})
+		}
+		if revokedAt.Valid && (filter.Since == 0 || revokedAt.Int64 >= filter.Since) {
 			*events = append(*events, ActivityEvent{
 				ID:           fmt.Sprintf("api-key-revoked-%s-%d", id, revokedAt.Int64),
 				ResourceType: "api_key",

--- a/internal/api/dashboard_test.go
+++ b/internal/api/dashboard_test.go
@@ -134,6 +134,290 @@ func TestActivityList_ReturnsRecentEvents(t *testing.T) {
 	assert.Contains(t, actions, "api_key.revoked")
 }
 
+// seedActivityData populates a tenant with services, builds, databases, and
+// API keys so that the activity endpoint returns a variety of event types.
+// Returns the auth token and server.
+func seedActivityData(t *testing.T) (string, *Server) {
+	t.Helper()
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+	token := seedAuthenticatedTenant(t, stateDB, masterKey)
+
+	// Service: svc-1 created at 10, updated (circuit_open) at 40
+	_, err := stateDB.Exec(`INSERT INTO services (id, tenant_id, name, status, image, port, last_error, crash_count, circuit_open, created_at, updated_at) VALUES ('svc-1', 'tenant-1', 'web', 'failed', 'nginx:latest', 8080, 'deploy queue full', 2, 1, 10, 40)`)
+	require.NoError(t, err)
+	// Service: svc-2 created at 50, running at 60
+	_, err = stateDB.Exec(`INSERT INTO services (id, tenant_id, name, status, image, port, last_error, crash_count, circuit_open, created_at, updated_at) VALUES ('svc-2', 'tenant-1', 'api', 'running', 'node:latest', 3000, '', 0, 0, 50, 60)`)
+	require.NoError(t, err)
+	// Build for svc-1: created at 20, started at 21, finished (failed) at 30
+	_, err = stateDB.Exec(`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_url, source_ref, image, created_at, started_at, finished_at) VALUES ('b-1', 'svc-1', 'tenant-1', 'failed', 'git', 'https://github.com/example/repo', 'main', '127.0.0.1:5000/ah/image', 20, 21, 30)`)
+	require.NoError(t, err)
+	// Database: created at 12, ready at 35
+	_, err = stateDB.Exec(`INSERT INTO databases (id, tenant_id, name, type, status, host, port, db_name, username, password_encrypted, connection_string_encrypted, volume_name, created_at, updated_at) VALUES ('db-1', 'tenant-1', 'cache', 'redis', 'ready', '127.0.0.1', 6379, '', '', 'enc', 'enc', 'vol-1', 12, 35)`)
+	require.NoError(t, err)
+	// Extra API key: created at 15, revoked at 25
+	_, err = stateDB.Exec(`INSERT INTO api_keys (id, tenant_id, name, key_prefix, key_hash, created_at, revoked_at) VALUES ('key-extra', 'tenant-1', 'dashboard', 'key-extr', 'hash', 15, 25)`)
+	require.NoError(t, err)
+
+	srv := NewServer(ServerConfig{
+		Store:     &db.Store{StateDB: stateDB},
+		MasterKey: masterKey,
+		DevMode:   true,
+	})
+	return token, srv
+}
+
+func TestActivityList_FilterByResourceType(t *testing.T) {
+	token, srv := seedActivityData(t)
+
+	tests := []struct {
+		name          string
+		resourceType  string
+		wantTypes     []string // all events should have one of these types
+		forbidTypes   []string // no event should have these types
+		wantNonEmpty  bool
+	}{
+		{
+			name:         "service only",
+			resourceType: "service",
+			wantTypes:    []string{"service"},
+			forbidTypes:  []string{"build", "database", "api_key", "tenant"},
+			wantNonEmpty: true,
+		},
+		{
+			name:         "build only",
+			resourceType: "build",
+			wantTypes:    []string{"build"},
+			forbidTypes:  []string{"service", "database", "api_key", "tenant"},
+			wantNonEmpty: true,
+		},
+		{
+			name:         "database only",
+			resourceType: "database",
+			wantTypes:    []string{"database"},
+			forbidTypes:  []string{"service", "build", "api_key", "tenant"},
+			wantNonEmpty: true,
+		},
+		{
+			name:         "api_key only",
+			resourceType: "api_key",
+			wantTypes:    []string{"api_key"},
+			forbidTypes:  []string{"service", "build", "database", "tenant"},
+			wantNonEmpty: true,
+		},
+		{
+			name:         "tenant only",
+			resourceType: "tenant",
+			wantTypes:    []string{"tenant"},
+			forbidTypes:  []string{"service", "build", "database", "api_key"},
+			wantNonEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/v1/activity?resource_type="+tt.resourceType, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var events []ActivityEvent
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &events))
+			if tt.wantNonEmpty {
+				require.NotEmpty(t, events)
+			}
+			for _, e := range events {
+				assert.Contains(t, tt.wantTypes, e.ResourceType, "unexpected resource_type %q", e.ResourceType)
+				for _, ft := range tt.forbidTypes {
+					assert.NotEqual(t, ft, e.ResourceType, "should not contain resource_type %q", ft)
+				}
+			}
+		})
+	}
+}
+
+func TestActivityList_FilterByAction(t *testing.T) {
+	token, srv := seedActivityData(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/activity?action=build.failed", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var events []ActivityEvent
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &events))
+	require.Len(t, events, 1)
+	assert.Equal(t, "build.failed", events[0].Action)
+}
+
+func TestActivityList_FilterByServiceID(t *testing.T) {
+	token, srv := seedActivityData(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/activity?service_id=svc-1", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var events []ActivityEvent
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &events))
+	require.NotEmpty(t, events)
+
+	// All events should relate to svc-1 (either service events or build events for svc-1).
+	for _, e := range events {
+		assert.True(t, e.ResourceType == "service" || e.ResourceType == "build",
+			"service_id filter should only return service/build events, got %q", e.ResourceType)
+		if e.ResourceType == "service" {
+			assert.Equal(t, "svc-1", e.ResourceID)
+		}
+		// Build events have ServiceID set.
+		if e.ResourceType == "build" {
+			assert.Equal(t, "svc-1", e.ServiceID)
+		}
+	}
+
+	// Must not include events for svc-2.
+	for _, e := range events {
+		if e.ResourceType == "service" {
+			assert.NotEqual(t, "svc-2", e.ResourceID)
+		}
+	}
+}
+
+func TestActivityList_FilterCombined(t *testing.T) {
+	token, srv := seedActivityData(t)
+
+	// Combine resource_type=service with action=service.circuit_open.
+	req := httptest.NewRequest(http.MethodGet, "/v1/activity?resource_type=service&action=service.circuit_open", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var events []ActivityEvent
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &events))
+	require.Len(t, events, 1)
+	assert.Equal(t, "service", events[0].ResourceType)
+	assert.Equal(t, "service.circuit_open", events[0].Action)
+}
+
+func TestActivityList_FilterSince(t *testing.T) {
+	token, srv := seedActivityData(t)
+
+	// Only events at or after timestamp 30.
+	req := httptest.NewRequest(http.MethodGet, "/v1/activity?since=30", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var events []ActivityEvent
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &events))
+	require.NotEmpty(t, events)
+
+	for _, e := range events {
+		assert.GreaterOrEqual(t, e.CreatedAt, int64(30), "event %s at %d should be >= 30", e.Action, e.CreatedAt)
+	}
+}
+
+func TestActivityList_FilterOffset(t *testing.T) {
+	token, srv := seedActivityData(t)
+
+	// Get all events first.
+	req := httptest.NewRequest(http.MethodGet, "/v1/activity?limit=200", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var allEvents []ActivityEvent
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &allEvents))
+	total := len(allEvents)
+	require.Greater(t, total, 2, "need at least 3 events for offset test")
+
+	// Get events with offset=2.
+	req = httptest.NewRequest(http.MethodGet, "/v1/activity?limit=200&offset=2", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var offsetEvents []ActivityEvent
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &offsetEvents))
+	assert.Len(t, offsetEvents, total-2)
+
+	// The offset events should match the tail of all events.
+	for i, e := range offsetEvents {
+		assert.Equal(t, allEvents[i+2].ID, e.ID)
+	}
+}
+
+func TestActivityList_NoFilters_UnchangedBehavior(t *testing.T) {
+	token, srv := seedActivityData(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/activity?limit=200", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var events []ActivityEvent
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &events))
+	require.NotEmpty(t, events)
+
+	// Should contain events from all resource types.
+	types := map[string]bool{}
+	for _, e := range events {
+		types[e.ResourceType] = true
+	}
+	assert.True(t, types["service"], "should have service events")
+	assert.True(t, types["build"], "should have build events")
+	assert.True(t, types["database"], "should have database events")
+	assert.True(t, types["api_key"], "should have api_key events")
+	assert.True(t, types["tenant"], "should have tenant events")
+
+	// Verify descending timestamp order.
+	for i := 1; i < len(events); i++ {
+		assert.GreaterOrEqual(t, events[i-1].CreatedAt, events[i].CreatedAt, "events should be in descending order")
+	}
+}
+
+func TestActivityList_InvalidParams(t *testing.T) {
+	token, srv := seedActivityData(t)
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"bad since", "/v1/activity?since=abc", "since must be a non-negative unix timestamp"},
+		{"negative since", "/v1/activity?since=-1", "since must be a non-negative unix timestamp"},
+		{"bad offset", "/v1/activity?offset=abc", "offset must be a non-negative integer"},
+		{"negative offset", "/v1/activity?offset=-1", "offset must be a non-negative integer"},
+		{"bad limit", "/v1/activity?limit=0", "limit must be between 1 and 200"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), tt.want)
+		})
+	}
+}
+
 func TestBuildLogsStream_Returns404WhenBuildNotFound(t *testing.T) {
 	stateDB := testutil.NewStateDB(t)
 	masterKey := []byte("0123456789abcdef0123456789abcdef")


### PR DESCRIPTION
## Summary
- Adds `?resource_type`, `?action`, `?service_id`, `?since`, `?offset` query parameters to GET /v1/activity
- All filters optional and AND-combinable
- resource_type skips irrelevant DB tables for efficiency
- Adds service_id field to activity events for service/build resources
- 8 new tests covering all filter dimensions

## Test plan
- [x] `TestActivityList_FilterByResourceType`
- [x] `TestActivityList_FilterByAction`
- [x] `TestActivityList_FilterByServiceID`
- [x] `TestActivityList_FilterCombined`
- [x] `TestActivityList_FilterSince`
- [x] `TestActivityList_FilterOffset`
- [x] `TestActivityList_NoFilters_UnchangedBehavior`
- [x] `TestActivityList_InvalidParams`
- [x] `go test ./...` passes
Closes #89
🤖 Generated with [Claude Code](https://claude.com/claude-code)