### PR TITLE
fix(#100): standardize quota exceeded errors to 409 Conflict

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -70,7 +70,7 @@ func (s *Server) handleKeyCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if keyCount >= maxKeysPerTenant {
-		writeError(w, http.StatusForbidden, "maximum API keys reached, revoke unused keys first")
+		writeError(w, http.StatusConflict, "quota exceeded: maximum API keys reached, revoke unused keys first")
 		return
 	}
 

--- a/internal/api/recovery.go
+++ b/internal/api/recovery.go
@@ -108,7 +108,7 @@ func (s *Server) handleKeyRecover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if keyCount >= maxKeysPerTenant {
-		writeError(w, http.StatusForbidden, "maximum API keys reached; revoke unused keys first")
+		writeError(w, http.StatusConflict, "quota exceeded: maximum API keys reached; revoke unused keys first")
 		return
 	}
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -374,6 +375,80 @@ func TestServiceDeployments_NotFound_Returns404(t *testing.T) {
 	srv.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// TestKeyCreate_QuotaExceeded_Returns409 verifies that creating an API key
+// when the tenant has reached maxKeysPerTenant returns 409 Conflict (not 403).
+// This is part of the fix for issue #100: standardize quota exceeded errors.
+func TestKeyCreate_QuotaExceeded_Returns409(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+	token := seedAuthenticatedTenant(t, stateDB, masterKey)
+
+	// Fill up all key slots (seedAuthenticatedTenant already created 1 key)
+	for i := 1; i < maxKeysPerTenant; i++ {
+		_, err := stateDB.Exec(
+			`INSERT INTO api_keys (id, tenant_id, name, key_prefix, key_hash, created_at)
+			 VALUES (?, ?, ?, ?, ?, 1)`,
+			"fill-key-"+strconv.Itoa(i), "tenant-1", "fill", "fill"+strconv.Itoa(i)+"xx", "hash",
+		)
+		require.NoError(t, err)
+	}
+
+	srv := NewServer(ServerConfig{
+		Store:     &db.Store{StateDB: stateDB},
+		MasterKey: masterKey,
+		DevMode:   true,
+	})
+
+	body := []byte(`{"name":"one-too-many"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/keys", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusConflict, rr.Code, "API key quota exceeded should return 409 Conflict")
+	assert.Contains(t, rr.Body.String(), "quota exceeded")
+}
+
+// TestTenantRegister_MaxTenants_Returns409 verifies that registering a new tenant
+// when the maximum is reached returns 409 Conflict (not 403).
+func TestTenantRegister_MaxTenants_Returns409(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+	// Insert maxTenants active tenants to fill the cap
+	for i := 0; i < maxTenants; i++ {
+		id := "tenant-fill-" + strconv.Itoa(i)
+		_, err := stateDB.Exec(
+			`INSERT INTO tenants (id, name, email, status, created_at, updated_at)
+			 VALUES (?, ?, ?, 'active', 1, 1)`,
+			id, "T"+strconv.Itoa(i), "t"+strconv.Itoa(i)+"@example.com",
+		)
+		require.NoError(t, err)
+	}
+
+	srv := NewServer(ServerConfig{
+		Store:            &db.Store{StateDB: stateDB},
+		MasterKey:        masterKey,
+		DevMode:          true,
+		OpenRegistration: true, // skip bootstrap token for test simplicity
+	})
+
+	body := []byte(`{"name":"New Tenant","email":"new@example.com"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/tenants/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// Use a unique IP to avoid rate limiter collisions with other tests
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("X-Real-Ip", "10.99.99.1")
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusConflict, rr.Code, "max tenants reached should return 409 Conflict")
+	assert.Contains(t, rr.Body.String(), "quota exceeded")
 }
 
 func seedAuthenticatedTenant(t *testing.T, stateDB *sql.DB, masterKey []byte) string {

--- a/internal/api/tenants.go
+++ b/internal/api/tenants.go
@@ -199,7 +199,7 @@ func (s *Server) handleTenantRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if tenantCount >= maxTenants {
-		writeError(w, http.StatusForbidden, "maximum tenants reached")
+		writeError(w, http.StatusConflict, "quota exceeded: maximum tenants reached")
 		return
 	}
 

--- a/internal/apierr/errors.go
+++ b/internal/apierr/errors.go
@@ -50,9 +50,10 @@ func Validation(msg string) *APIError {
 	return &APIError{Code: http.StatusBadRequest, Message: msg, Err: ErrValidation}
 }
 
-// QuotaExceeded returns a 403 error.
+// QuotaExceeded returns a 409 Conflict error for resource quota limits.
+// 409 is used (not 429) because quota exceeded is a resource conflict, not a rate limit.
 func QuotaExceeded(msg string) *APIError {
-	return &APIError{Code: http.StatusForbidden, Message: msg, Err: ErrQuotaExceeded}
+	return &APIError{Code: http.StatusConflict, Message: msg, Err: ErrQuotaExceeded}
 }
 
 // Forbidden returns a 403 error.

--- a/internal/apierr/errors_test.go
+++ b/internal/apierr/errors_test.go
@@ -53,7 +53,7 @@ func TestAllConstructors(t *testing.T) {
 		{NotFound, ErrNotFound, 404},
 		{Conflict, ErrConflict, 409},
 		{Validation, ErrValidation, 400},
-		{QuotaExceeded, ErrQuotaExceeded, 403},
+		{QuotaExceeded, ErrQuotaExceeded, 409},
 		{Forbidden, ErrForbidden, 403},
 	}
 	for _, tt := range tests {

--- a/internal/databases/databases.go
+++ b/internal/databases/databases.go
@@ -148,7 +148,7 @@ func (m *Manager) Create(ctx context.Context, tenantID string, req CreateRequest
 	}
 	if count >= maxDatabases {
 		tx.Rollback()
-		return nil, apierr.QuotaExceeded(fmt.Sprintf("database quota exceeded (max %d)", maxDatabases))
+		return nil, apierr.QuotaExceeded(fmt.Sprintf("quota exceeded: maximum %d databases reached", maxDatabases))
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit quota check: %w", err)

--- a/internal/databases/databases_test.go
+++ b/internal/databases/databases_test.go
@@ -250,7 +250,7 @@ func TestCreate_UsesTenantMaxDatabasesQuota(t *testing.T) {
 	second, err := mgr.Create(context.Background(), "tenant-1", CreateRequest{Name: "db-2", Type: "postgres"})
 	require.Error(t, err)
 	assert.Nil(t, second)
-	assert.ErrorContains(t, err, "database quota exceeded (max 1)")
+	assert.ErrorContains(t, err, "quota exceeded: maximum 1 databases reached")
 }
 
 // TestDelete_WipesVolumeBeforeRemoval verifies that WipeVolume is called before

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -439,7 +439,7 @@ func (m *Manager) Create(ctx context.Context, tenantID string, req CreateRequest
 		return nil, fmt.Errorf("count services: %w", err)
 	}
 	if currentCount >= maxServices {
-		return nil, apierr.QuotaExceeded(fmt.Sprintf("service limit reached (max %d)", maxServices))
+		return nil, apierr.QuotaExceeded(fmt.Sprintf("quota exceeded: maximum %d services reached", maxServices))
 	}
 
 	id, err := generateID()


### PR DESCRIPTION
## Summary
- Changes all quota exceeded errors from 403 to 409 Conflict
- Standardizes error messages to `"quota exceeded: maximum N {resource} reached"`
- Keeps 429 only for rate limiting (middleware)
- Updated apierr.QuotaExceeded, auth, recovery, tenants, services, databases
- 2 new tests + updated existing assertions

## Test plan
- [x] `TestKeyCreate_QuotaExceeded_Returns409`
- [x] `TestTenantRegister_MaxTenants_Returns409`
- [x] `go test ./...` passes
Closes #100
🤖 Generated with [Claude Code](https://claude.com/claude-code)