### PR TITLE
feat(#106): preserve final 500 lines of build logs at 5MB cap

### DIFF
--- a/internal/builds/builds.go
+++ b/internal/builds/builds.go
@@ -21,6 +21,7 @@ import (
 )
 
 const maxLogSize = 5 * 1024 * 1024 // 5MB max log per build
+const tailLines = 500              // lines to preserve when log is truncated
 
 // Build represents a build record.
 type Build struct {
@@ -55,6 +56,15 @@ type buildExecutor interface {
 	CancelBuild(buildID string) error
 }
 
+// logState tracks per-build log accumulation and tail buffer.
+type logState struct {
+	size      int        // current log size in bytes
+	truncated bool       // whether the log has been truncated
+	tail      []string   // ring buffer of last tailLines lines
+	tailIdx   int        // next write position in tail ring buffer
+	tailCount int        // total lines written to tail (for omission count)
+}
+
 // Manager coordinates build lifecycle.
 type Manager struct {
 	db         *sql.DB
@@ -63,7 +73,7 @@ type Manager struct {
 	logMu      sync.Mutex
 	buildQueue chan struct{}            // bounded queue for build goroutines
 	logSubs    map[string][]chan string // buildID -> subscribers
-	logSizes   map[string]int           // buildID -> current log size in bytes
+	logStates  map[string]*logState    // buildID -> log accumulation state
 }
 
 // NewManager creates a build manager.
@@ -74,7 +84,7 @@ func NewManager(db *sql.DB, b buildExecutor, deployFn DeployFunc) *Manager {
 		deployFn:   deployFn,
 		buildQueue: make(chan struct{}, 10), // max 10 queued builds
 		logSubs:    make(map[string][]chan string),
-		logSizes:   make(map[string]int),
+		logStates:  make(map[string]*logState),
 	}
 	// Mark any stale builds from previous process as failed
 	m.reconcileStaleBuilds()
@@ -221,9 +231,10 @@ func (m *Manager) runBuild(buildID, tenantID, serviceID string, req builder.Buil
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 	defer func() {
-		// Clean up log size tracking
+		// Flush tail buffer if truncation occurred, then clean up
+		m.flushTailBuffer(ctx, buildID)
 		m.logMu.Lock()
-		delete(m.logSizes, buildID)
+		delete(m.logStates, buildID)
 		m.logMu.Unlock()
 	}()
 
@@ -298,15 +309,35 @@ func (m *Manager) runBuild(buildID, tenantID, serviceID string, req builder.Buil
 }
 
 func (m *Manager) appendLog(ctx context.Context, buildID, line string) {
-	// Enforce max log size
 	m.logMu.Lock()
-	currentSize := m.logSizes[buildID]
-	lineBytes := len(line) + 1 // +1 for newline
-	if currentSize+lineBytes > maxLogSize {
-		m.logMu.Unlock()
-		return // silently drop — log is full
+	ls := m.logStates[buildID]
+	if ls == nil {
+		ls = &logState{tail: make([]string, tailLines)}
+		m.logStates[buildID] = ls
 	}
-	m.logSizes[buildID] = currentSize + lineBytes
+
+	lineBytes := len(line) + 1 // +1 for newline
+
+	if ls.truncated {
+		// Log already exceeded cap — only buffer in the ring buffer
+		ls.tail[ls.tailIdx%tailLines] = line
+		ls.tailIdx++
+		ls.tailCount++
+		m.logMu.Unlock()
+		return
+	}
+
+	if ls.size+lineBytes > maxLogSize {
+		// First time exceeding the cap — switch to ring buffer mode
+		ls.truncated = true
+		ls.tail[ls.tailIdx%tailLines] = line
+		ls.tailIdx++
+		ls.tailCount++
+		m.logMu.Unlock()
+		return
+	}
+
+	ls.size += lineBytes
 	m.logMu.Unlock()
 
 	_, err := m.db.ExecContext(ctx,
@@ -316,6 +347,52 @@ func (m *Manager) appendLog(ctx context.Context, buildID, line string) {
 	if err != nil {
 		log.Printf("builds: failed to append log for %s: %v", buildID, err)
 	}
+}
+
+// flushTailBuffer replaces the DB log with a truncation notice + tail lines
+// if the build log was truncated during accumulation.
+func (m *Manager) flushTailBuffer(ctx context.Context, buildID string) {
+	m.logMu.Lock()
+	ls := m.logStates[buildID]
+	if ls == nil || !ls.truncated {
+		m.logMu.Unlock()
+		return
+	}
+
+	// Collect tail lines in order
+	lines := collectTailLines(ls)
+	omitted := ls.tailCount
+	m.logMu.Unlock()
+
+	header := fmt.Sprintf("[truncated: %d lines omitted, 5MB limit reached]\n", omitted)
+	tail := strings.Join(lines, "\n") + "\n"
+
+	// Replace the entire log with: original prefix (up to cap) is discarded,
+	// replaced by truncation notice + last N lines.
+	_, err := m.db.ExecContext(ctx,
+		`UPDATE builds SET log = ? WHERE id = ?`,
+		header+tail, buildID,
+	)
+	if err != nil {
+		log.Printf("builds: failed to flush tail buffer for %s: %v", buildID, err)
+	}
+}
+
+// collectTailLines extracts the tail ring buffer contents in chronological order.
+func collectTailLines(ls *logState) []string {
+	count := ls.tailCount
+	if count > tailLines {
+		count = tailLines
+	}
+	lines := make([]string, 0, count)
+	start := ls.tailIdx - count
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < ls.tailIdx; i++ {
+		lines = append(lines, ls.tail[i%tailLines])
+	}
+	return lines
 }
 
 func (m *Manager) notifyLogSubs(buildID, line string) {

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -124,4 +126,194 @@ func waitForBuildStatus(t *testing.T, stateDB *sql.DB, buildID, want string) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for build %s to reach status %q", buildID, want)
+}
+
+func TestAppendLog_SmallLogPreservedInFull(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	seedBuildTestData(t, stateDB)
+
+	mgr := NewManager(stateDB, &stubBuilder{}, nil)
+
+	// Insert a build record directly
+	buildID := "test-build-small"
+	_, err := stateDB.Exec(
+		`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_ref, image, log, created_at)
+		 VALUES (?, 'svc-1', 'tenant-1', 'running', 'git', 'main', 'img:latest', '', 1)`,
+		buildID,
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	// Append a modest number of lines
+	for i := 0; i < 100; i++ {
+		mgr.appendLog(ctx, buildID, fmt.Sprintf("line %d: some build output", i))
+	}
+	mgr.flushTailBuffer(ctx, buildID)
+
+	logs, err := mgr.GetBuildLogs(ctx, "tenant-1", buildID)
+	require.NoError(t, err)
+
+	// All 100 lines should be present — no truncation
+	assert.NotContains(t, logs, "[truncated:")
+	for i := 0; i < 100; i++ {
+		assert.Contains(t, logs, fmt.Sprintf("line %d: some build output", i))
+	}
+}
+
+func TestAppendLog_LargeLogTruncatedWithTail(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	seedBuildTestData(t, stateDB)
+
+	mgr := NewManager(stateDB, &stubBuilder{}, nil)
+
+	buildID := "test-build-large"
+	_, err := stateDB.Exec(
+		`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_ref, image, log, created_at)
+		 VALUES (?, 'svc-1', 'tenant-1', 'running', 'git', 'main', 'img:latest', '', 1)`,
+		buildID,
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Use large lines (~10KB each) so we hit the 5MB cap in ~520 DB writes,
+	// then write 600 more lines past the cap for the tail buffer.
+	bigPadding := strings.Repeat("X", 10*1024) // 10KB per line
+	linesBeforeCap := (maxLogSize / (10*1024 + 1)) + 1 // +1 for newline char
+	linesAfterCap := 600
+	totalLines := linesBeforeCap + linesAfterCap
+
+	for i := 0; i < totalLines; i++ {
+		mgr.appendLog(ctx, buildID, fmt.Sprintf("line-%06d:%s", i, bigPadding))
+	}
+	mgr.flushTailBuffer(ctx, buildID)
+
+	logs, err := mgr.GetBuildLogs(ctx, "tenant-1", buildID)
+	require.NoError(t, err)
+
+	// Should contain truncation notice
+	assert.Contains(t, logs, "[truncated:")
+	assert.Contains(t, logs, "5MB limit reached]")
+
+	// Should contain the last tailLines lines
+	logLines := strings.Split(strings.TrimRight(logs, "\n"), "\n")
+	// First line is the truncation header
+	assert.True(t, strings.HasPrefix(logLines[0], "[truncated:"), "first line should be truncation header")
+
+	// The tail should contain lines from the end
+	lastLineTag := fmt.Sprintf("line-%06d:", totalLines-1)
+	assert.Contains(t, logs, lastLineTag, "should contain the very last line")
+
+	// Should NOT contain the first line (it was truncated)
+	assert.NotContains(t, logs, "line-000000:")
+
+	_ = logLines // suppress unused warning
+}
+
+func TestAppendLog_TruncationMessageFormat(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	seedBuildTestData(t, stateDB)
+
+	mgr := NewManager(stateDB, &stubBuilder{}, nil)
+
+	buildID := "test-build-truncmsg"
+	_, err := stateDB.Exec(
+		`INSERT INTO builds (id, service_id, tenant_id, status, source_type, source_ref, image, log, created_at)
+		 VALUES (?, 'svc-1', 'tenant-1', 'running', 'git', 'main', 'img:latest', '', 1)`,
+		buildID,
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Use large lines to exceed 5MB quickly, then add exactly tailLines+100 more
+	bigLine := strings.Repeat("X", 10*1024)
+	linesBeforeCap := (maxLogSize / (10*1024 + 1)) + 1
+	totalLines := linesBeforeCap + tailLines + 100 // enough to fully fill the ring buffer
+
+	for i := 0; i < totalLines; i++ {
+		mgr.appendLog(ctx, buildID, fmt.Sprintf("L%06d %s", i, bigLine))
+	}
+	mgr.flushTailBuffer(ctx, buildID)
+
+	logs, err := mgr.GetBuildLogs(ctx, "tenant-1", buildID)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(logs, "\n"), "\n")
+
+	// The truncation header must be the very first line
+	assert.True(t, strings.HasPrefix(lines[0], "[truncated:"))
+	assert.True(t, strings.HasSuffix(lines[0], "5MB limit reached]"))
+
+	// After the header, there should be exactly tailLines (500) lines
+	assert.Equal(t, tailLines+1, len(lines), "should have header + 500 tail lines")
+}
+
+func TestCollectTailLines_FewerThanCapacity(t *testing.T) {
+	ls := &logState{tail: make([]string, tailLines)}
+	for i := 0; i < 10; i++ {
+		ls.tail[ls.tailIdx%tailLines] = fmt.Sprintf("line-%d", i)
+		ls.tailIdx++
+		ls.tailCount++
+	}
+
+	lines := collectTailLines(ls)
+	assert.Len(t, lines, 10)
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, fmt.Sprintf("line-%d", i), lines[i])
+	}
+}
+
+func TestCollectTailLines_WrapsAround(t *testing.T) {
+	ls := &logState{tail: make([]string, tailLines)}
+	total := tailLines + 200 // write more than capacity to wrap
+	for i := 0; i < total; i++ {
+		ls.tail[ls.tailIdx%tailLines] = fmt.Sprintf("line-%d", i)
+		ls.tailIdx++
+		ls.tailCount++
+	}
+
+	lines := collectTailLines(ls)
+	assert.Len(t, lines, tailLines)
+	// Should contain the last `tailLines` entries
+	for i := 0; i < tailLines; i++ {
+		expected := fmt.Sprintf("line-%d", total-tailLines+i)
+		assert.Equal(t, expected, lines[i])
+	}
+}
+
+func TestStartBuild_LogTruncationEndToEnd(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	seedBuildTestData(t, stateDB)
+
+	bigPadding := strings.Repeat("X", 10*1024) // 10KB lines for speed
+	mgr := NewManager(stateDB, &stubBuilder{
+		buildFn: func(ctx context.Context, req builder.BuildRequest, logCb func(string)) error {
+			// Generate enough log lines to exceed 5MB with large lines
+			for i := 0; i < 600; i++ {
+				logCb(fmt.Sprintf("build-line-%06d:%s", i, bigPadding))
+			}
+			return nil
+		},
+	}, nil)
+
+	build, err := mgr.StartBuild(context.Background(), "tenant-1", "svc-1", StartBuildRequest{
+		SourceType: "git",
+		SourceURL:  "https://github.com/example/repo.git",
+		SourceRef:  "main",
+	})
+	require.NoError(t, err)
+
+	waitForBuildStatus(t, stateDB, build.ID, "succeeded")
+
+	logs, err := mgr.GetBuildLogs(context.Background(), "tenant-1", build.ID)
+	require.NoError(t, err)
+
+	// Verify truncation happened
+	assert.Contains(t, logs, "[truncated:")
+	assert.Contains(t, logs, "5MB limit reached]")
+
+	// Verify the build completion lines from runBuild are in the tail
+	// (these are appended after the builder returns)
+	assert.Contains(t, logs, "[ah] Build complete")
 }


### PR DESCRIPTION
## Summary
- Replaces full truncation with ring-buffer tail preservation
- Keeps last 500 lines with truncation notice header when 5MB cap is hit
- Ring buffer collects lines in memory, flushes at build completion
- 6 new tests covering all truncation scenarios

## Test plan
- [x] Small logs preserved in full
- [x] Large logs truncated with tail preserved
- [x] Truncation message format verified
- [x] Ring buffer wraparound correctness
- [x] End-to-end test via StartBuild
- [x] `go test ./...` passes
Closes #106
🤖 Generated with [Claude Code](https://claude.com/claude-code)