### PR TITLE
feat(#107): tenant reactivation endpoint

### DIFF
--- a/internal/api/reactivate_test.go
+++ b/internal/api/reactivate_test.go
@@ -1,0 +1,214 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dennisonbertram/agentic-hosting/internal/db"
+	"github.com/dennisonbertram/agentic-hosting/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reactivateRequest builds a POST /v1/tenants/{tenantID}/reactivate request
+// with a distinct source IP so tests do not share the same rate-limit bucket.
+func reactivateRequest(ip, tenantID, bootstrapToken string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/tenants/"+tenantID+"/reactivate", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Bootstrap-Token", bootstrapToken)
+	// Set loopback RemoteAddr so trustedRealIP uses X-Real-Ip for rate limiting.
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("X-Real-Ip", ip)
+	return req
+}
+
+func TestHandleTenantReactivate(t *testing.T) {
+	const bootstrapToken = "test-bootstrap-token-for-reactivation"
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+	t.Run("successful reactivation of suspended tenant", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+		// Seed a suspended tenant with revoked keys (simulating post-DELETE state).
+		_, err := stateDB.Exec(
+			`INSERT INTO tenants (id, name, email, status, created_at, updated_at)
+			 VALUES (?, ?, ?, 'suspended', 1, 1)`,
+			"tenant-react", "Suspended Tenant", "suspended@example.com",
+		)
+		require.NoError(t, err)
+		_, err = stateDB.Exec(`INSERT INTO tenant_quotas (tenant_id) VALUES (?)`, "tenant-react")
+		require.NoError(t, err)
+
+		srv := NewServer(ServerConfig{
+			Store:          &db.Store{StateDB: stateDB},
+			MasterKey:      masterKey,
+			DevMode:        true,
+			BootstrapToken: bootstrapToken,
+		})
+
+		req := reactivateRequest("10.1.0.1", "tenant-react", bootstrapToken)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code, "expected 200, got: %s", rr.Body.String())
+
+		var resp ReactivateResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+		assert.Equal(t, "tenant-react", resp.TenantID, "response tenant_id should match")
+		assert.Equal(t, "active", resp.Status, "response status should be active")
+		assert.NotEmpty(t, resp.APIKey, "response should include a new API key")
+		assert.Contains(t, resp.APIKey, ".", "API key should be in keyID.secret format")
+
+		// Verify the tenant status was updated in the database.
+		var status string
+		err = stateDB.QueryRow(`SELECT status FROM tenants WHERE id = ?`, "tenant-react").Scan(&status)
+		require.NoError(t, err)
+		assert.Equal(t, "active", status, "tenant status should be active in DB")
+	})
+
+	t.Run("reactivation of already-active tenant returns 409", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+		_, err := stateDB.Exec(
+			`INSERT INTO tenants (id, name, email, status, created_at, updated_at)
+			 VALUES (?, ?, ?, 'active', 1, 1)`,
+			"tenant-active", "Active Tenant", "active@example.com",
+		)
+		require.NoError(t, err)
+		_, err = stateDB.Exec(`INSERT INTO tenant_quotas (tenant_id) VALUES (?)`, "tenant-active")
+		require.NoError(t, err)
+
+		srv := NewServer(ServerConfig{
+			Store:          &db.Store{StateDB: stateDB},
+			MasterKey:      masterKey,
+			DevMode:        true,
+			BootstrapToken: bootstrapToken,
+		})
+
+		req := reactivateRequest("10.1.0.2", "tenant-active", bootstrapToken)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusConflict, rr.Code, "already-active tenant should return 409")
+	})
+
+	t.Run("reactivation of non-existent tenant returns 404", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+
+		srv := NewServer(ServerConfig{
+			Store:          &db.Store{StateDB: stateDB},
+			MasterKey:      masterKey,
+			DevMode:        true,
+			BootstrapToken: bootstrapToken,
+		})
+
+		req := reactivateRequest("10.1.0.3", "does-not-exist", bootstrapToken)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusNotFound, rr.Code, "non-existent tenant should return 404")
+	})
+
+	t.Run("reactivation without bootstrap token returns 401", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+		_, err := stateDB.Exec(
+			`INSERT INTO tenants (id, name, email, status, created_at, updated_at)
+			 VALUES (?, ?, ?, 'suspended', 1, 1)`,
+			"tenant-notoken", "Suspended", "notoken@example.com",
+		)
+		require.NoError(t, err)
+
+		srv := NewServer(ServerConfig{
+			Store:          &db.Store{StateDB: stateDB},
+			MasterKey:      masterKey,
+			DevMode:        true,
+			BootstrapToken: bootstrapToken,
+		})
+
+		req := reactivateRequest("10.1.0.4", "tenant-notoken", "wrong-token")
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code, "wrong bootstrap token should return 401")
+	})
+
+	t.Run("reactivation with missing bootstrap token header returns 401", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+
+		srv := NewServer(ServerConfig{
+			Store:          &db.Store{StateDB: stateDB},
+			MasterKey:      masterKey,
+			DevMode:        true,
+			BootstrapToken: bootstrapToken,
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/tenants/some-tenant/reactivate", nil)
+		req.RemoteAddr = "127.0.0.1:1234"
+		req.Header.Set("X-Real-Ip", "10.1.0.5")
+		// No X-Bootstrap-Token header set.
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code, "missing bootstrap token should return 401")
+	})
+
+	t.Run("reactivation when bootstrap token not configured returns 503", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+
+		srv := NewServer(ServerConfig{
+			Store:     &db.Store{StateDB: stateDB},
+			MasterKey: masterKey,
+			DevMode:   true,
+			// BootstrapToken intentionally omitted
+		})
+
+		req := reactivateRequest("10.1.0.6", "some-tenant", "anything")
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rr.Code, "unconfigured bootstrap token should return 503")
+	})
+
+	t.Run("reactivated tenant key is usable for authenticated requests", func(t *testing.T) {
+		stateDB := testutil.NewStateDB(t)
+		_, err := stateDB.Exec(
+			`INSERT INTO tenants (id, name, email, status, created_at, updated_at)
+			 VALUES (?, ?, ?, 'suspended', 1, 1)`,
+			"tenant-usekey", "Suspended Tenant", "usekey@example.com",
+		)
+		require.NoError(t, err)
+		_, err = stateDB.Exec(`INSERT INTO tenant_quotas (tenant_id) VALUES (?)`, "tenant-usekey")
+		require.NoError(t, err)
+
+		srv := NewServer(ServerConfig{
+			Store:          &db.Store{StateDB: stateDB},
+			MasterKey:      masterKey,
+			DevMode:        true,
+			BootstrapToken: bootstrapToken,
+		})
+
+		// Step 1: reactivate the tenant.
+		reactReq := reactivateRequest("10.1.0.7", "tenant-usekey", bootstrapToken)
+		reactRR := httptest.NewRecorder()
+		srv.ServeHTTP(reactRR, reactReq)
+		require.Equal(t, http.StatusOK, reactRR.Code, "reactivation should return 200, got: %s", reactRR.Body.String())
+
+		var resp ReactivateResponse
+		require.NoError(t, json.NewDecoder(reactRR.Body).Decode(&resp))
+
+		// Step 2: use the new key to call an authenticated endpoint.
+		tenantReq := httptest.NewRequest(http.MethodGet, "/v1/tenant", nil)
+		tenantReq.Header.Set("Authorization", "Bearer "+resp.APIKey)
+		tenantRR := httptest.NewRecorder()
+		srv.ServeHTTP(tenantRR, tenantReq)
+
+		assert.Equal(t, http.StatusOK, tenantRR.Code,
+			"reactivated key should authenticate successfully: %s", tenantRR.Body.String())
+
+		// Verify the returned tenant is actually active.
+		var tenant TenantResponse
+		require.NoError(t, json.NewDecoder(tenantRR.Body).Decode(&tenant))
+		assert.Equal(t, "active", tenant.Status, "tenant should show active status")
+		assert.Equal(t, "tenant-usekey", tenant.ID)
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -146,6 +146,9 @@ func (s *Server) setupRoutes() {
 		// Recovery endpoint: authenticated by bootstrap token, not an API key.
 		// Allows tenants who have lost all their keys to obtain a new one.
 		r.Post("/v1/auth/recover", s.handleKeyRecover)
+		// Reactivation endpoint: authenticated by bootstrap token, not an API key.
+		// Allows operator to reactivate a suspended tenant and generate a new API key.
+		r.Post("/v1/tenants/{tenantID}/reactivate", s.handleTenantReactivate)
 	})
 
 	// Authenticated short-lived routes keep the standard request timeout.

--- a/internal/api/tenants.go
+++ b/internal/api/tenants.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dennisonbertram/agentic-hosting/internal/cache"
 	"github.com/dennisonbertram/agentic-hosting/internal/crypto"
 	"github.com/dennisonbertram/agentic-hosting/internal/middleware"
+	"github.com/go-chi/chi/v5"
 )
 
 type RegisterRequest struct {
@@ -411,6 +412,133 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// ReactivateResponse is the response body for POST /v1/tenants/{tenantID}/reactivate.
+// It returns the new API key so the operator can hand it to the tenant.
+type ReactivateResponse struct {
+	TenantID string `json:"tenant_id"`
+	APIKey   string `json:"api_key"`
+	Status   string `json:"status"`
+}
+
+// handleTenantReactivate handles POST /v1/tenants/{tenantID}/reactivate.
+//
+// Security model:
+//   - Rate-limited by the same per-IP / global limiter used for tenant
+//     registration (5/IP/hour, 20/global/hour).
+//   - Requires bootstrap token via X-Bootstrap-Token header.
+//   - Only suspended tenants can be reactivated; already-active returns 409.
+//   - A new API key is generated and returned (one-time display).
+func (s *Server) handleTenantReactivate(w http.ResponseWriter, r *http.Request) {
+	// Apply the same rate limiter as tenant registration to prevent
+	// brute-force of the bootstrap token via this endpoint.
+	ip := trustedRealIP(r)
+	if ok, wait := regLimiter.allow(ip); !ok {
+		secs := int(math.Ceil(wait.Seconds()))
+		if secs < 1 {
+			secs = 1
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
+		writeError(w, http.StatusTooManyRequests, "rate limit exceeded, try again later")
+		return
+	}
+
+	// Fail closed: reject if bootstrap token is not configured.
+	if s.bootstrapToken == "" {
+		writeError(w, http.StatusServiceUnavailable, "reactivation temporarily unavailable")
+		return
+	}
+
+	// Verify bootstrap token via HMAC-compare (no length leak).
+	provided := strings.TrimSpace(r.Header.Get("X-Bootstrap-Token"))
+	if !hmacEqual(provided, s.bootstrapToken, s.masterKey) {
+		writeError(w, http.StatusUnauthorized, "missing or invalid bootstrap token")
+		return
+	}
+
+	tenantID := chi.URLParam(r, "tenantID")
+	if tenantID == "" {
+		writeError(w, http.StatusBadRequest, "tenant ID is required")
+		return
+	}
+
+	// Look up the tenant and check its current status.
+	var currentStatus string
+	err := s.store.StateDB.QueryRow(
+		`SELECT status FROM tenants WHERE id = ?`, tenantID,
+	).Scan(&currentStatus)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "tenant not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	if currentStatus == "active" {
+		writeError(w, http.StatusConflict, "tenant is already active")
+		return
+	}
+
+	now := time.Now().Unix()
+
+	tx, err := s.store.StateDB.Begin()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	defer tx.Rollback()
+
+	// Set tenant status back to active.
+	_, err = tx.Exec(
+		`UPDATE tenants SET status = 'active', updated_at = ? WHERE id = ?`,
+		now, tenantID,
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to reactivate tenant")
+		return
+	}
+
+	// Generate a new API key for the reactivated tenant since all keys
+	// were revoked on suspension.
+	apiKey, keyID, err := crypto.GenerateAPIKeyWithID()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	keyHash := crypto.HashAPIKey(apiKey, s.masterKey)
+	if len(keyID) < 8 {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	prefix := keyID[:8]
+
+	_, err = tx.Exec(
+		`INSERT INTO api_keys (id, tenant_id, name, key_prefix, key_hash, created_at)
+		 VALUES (?, ?, 'reactivation', ?, ?, ?)`,
+		keyID, tenantID, prefix, keyHash, now,
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create reactivation key")
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// Return token in format "keyID.secret" for O(1) lookup.
+	token := keyID + "." + apiKey
+
+	writeJSON(w, http.StatusOK, ReactivateResponse{
+		TenantID: tenantID,
+		APIKey:   token,
+		Status:   "active",
+	})
 }
 
 // hmacEqual compares two strings in constant time regardless of length.


### PR DESCRIPTION
## Summary
- Adds `POST /v1/tenants/{tenantID}/reactivate` requiring bootstrap token
- Transitions tenant from suspended to active
- Generates and returns a new API key
- Returns 404/409/401/503 for edge cases
- Rate-limited like registration (5/IP/hour)
- 7 tests covering all scenarios

## Test plan
- [x] Successful reactivation returns 200 + API key
- [x] 409 for already-active tenant
- [x] 404 for non-existent tenant
- [x] 401 for invalid/missing bootstrap token
- [x] Key-usability integration test
- [x] `go test ./...` passes
Closes #107
🤖 Generated with [Claude Code](https://claude.com/claude-code)