### PR TITLE
feat(#103): snapshot retention policies and automatic cleanup

### DIFF
--- a/cmd/ah/main.go
+++ b/cmd/ah/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dennisonbertram/agentic-hosting/internal/kanbans"
 	"github.com/dennisonbertram/agentic-hosting/internal/reconciler"
 	"github.com/dennisonbertram/agentic-hosting/internal/services"
+	"github.com/dennisonbertram/agentic-hosting/internal/snapshots"
 )
 
 func main() {
@@ -214,6 +215,11 @@ func main() {
 	gcCtx, gcCancel := context.WithCancel(context.Background())
 	defer gcCancel()
 	garbageCollector := gc.New(store.StateDB, dockerClient, 5*time.Minute, cfg.BuildDir)
+
+	// Wire snapshot retention into GC
+	snapMgr := snapshots.NewManager(store.StateDB, dockerClient, masterKey[:32])
+	garbageCollector.SetSnapshotCleaner(snapMgr, cfg.SnapshotMaxPerService, cfg.SnapshotMaxAge)
+
 	go garbageCollector.Run(gcCtx)
 
 	<-done

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,9 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // Config holds all configurable paths and addresses for the ah server.
@@ -18,9 +20,19 @@ type Config struct {
 	DockerDataDir    string // Docker data root for disk checks (default: /var/lib/docker)
 	BaseDomain       string // base domain for public service URLs (default: "" = localhost fallback)
 	TraefikConfigDir string // Traefik file provider dynamic config directory (default: /etc/traefik/dynamic)
+
+	// Snapshot retention
+	SnapshotMaxPerService int           // max snapshots kept per service (default: 10, 0 = unlimited)
+	SnapshotMaxAge        time.Duration // max age before a snapshot is eligible for cleanup (default: 30d, 0 = unlimited)
 }
 
 const defaultDataDir = "/var/lib/ah"
+
+// Snapshot retention defaults.
+const (
+	DefaultSnapshotMaxPerService = 10
+	DefaultSnapshotMaxAge        = 30 * 24 * time.Hour // 30 days
+)
 
 // Default returns a Config with all default values.
 func Default() Config {
@@ -31,8 +43,10 @@ func Default() Config {
 		MasterKeyPath:    filepath.Join(defaultDataDir, "master.key"),
 		BuildDir:         filepath.Join(defaultDataDir, "builds"),
 		NixpacksPath:     "/usr/local/bin/nixpacks",
-		DockerDataDir:    "/var/lib/docker",
-		TraefikConfigDir: "/etc/traefik/dynamic",
+		DockerDataDir:         "/var/lib/docker",
+		TraefikConfigDir:      "/etc/traefik/dynamic",
+		SnapshotMaxPerService: DefaultSnapshotMaxPerService,
+		SnapshotMaxAge:        DefaultSnapshotMaxAge,
 	}
 }
 
@@ -43,15 +57,17 @@ func FromEnv() Config {
 	dataDir := envOr("AH_DATA_DIR", defaultDataDir)
 
 	return Config{
-		DataDir:          dataDir,
-		DBPath:           envOr("AH_DB_PATH", filepath.Join(dataDir, "ah.db")),
-		MeterDBPath:      envOr("AH_METER_DB_PATH", filepath.Join(dataDir, "meter.db")),
-		MasterKeyPath:    envOr("AH_MASTER_KEY_PATH", filepath.Join(dataDir, "master.key")),
-		BuildDir:         envOr("AH_BUILD_DIR", filepath.Join(dataDir, "builds")),
-		NixpacksPath:     envOr("AH_NIXPACKS_PATH", "/usr/local/bin/nixpacks"),
-		DockerDataDir:    envOr("AH_DOCKER_DATA_DIR", "/var/lib/docker"),
-		BaseDomain:       strings.TrimSpace(os.Getenv("AH_BASE_DOMAIN")),
-		TraefikConfigDir: envOr("AH_TRAEFIK_CONFIG_DIR", "/etc/traefik/dynamic"),
+		DataDir:               dataDir,
+		DBPath:                envOr("AH_DB_PATH", filepath.Join(dataDir, "ah.db")),
+		MeterDBPath:           envOr("AH_METER_DB_PATH", filepath.Join(dataDir, "meter.db")),
+		MasterKeyPath:         envOr("AH_MASTER_KEY_PATH", filepath.Join(dataDir, "master.key")),
+		BuildDir:              envOr("AH_BUILD_DIR", filepath.Join(dataDir, "builds")),
+		NixpacksPath:          envOr("AH_NIXPACKS_PATH", "/usr/local/bin/nixpacks"),
+		DockerDataDir:         envOr("AH_DOCKER_DATA_DIR", "/var/lib/docker"),
+		BaseDomain:            strings.TrimSpace(os.Getenv("AH_BASE_DOMAIN")),
+		TraefikConfigDir:      envOr("AH_TRAEFIK_CONFIG_DIR", "/etc/traefik/dynamic"),
+		SnapshotMaxPerService: envOrInt("AH_SNAPSHOT_MAX_PER_SERVICE", DefaultSnapshotMaxPerService),
+		SnapshotMaxAge:        envOrDuration("AH_SNAPSHOT_MAX_AGE", DefaultSnapshotMaxAge),
 	}
 }
 
@@ -65,4 +81,28 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func envOrInt(key string, fallback int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return n
+}
+
+func envOrDuration(key string, fallback time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fallback
+	}
+	return d
 }

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -14,12 +14,23 @@ import (
 	"github.com/dennisonbertram/agentic-hosting/internal/docker"
 )
 
+// SnapshotCleaner is the interface used by GC to clean expired snapshots.
+// The snapshots.Manager satisfies this interface.
+type SnapshotCleaner interface {
+	CleanExpired(ctx context.Context, maxPerService int, maxAge time.Duration) (int, error)
+}
+
 // GC cleans up orphaned containers, volumes, images, and build dirs.
 type GC struct {
 	db       *sql.DB
 	docker   docker.Client
 	interval time.Duration
 	buildDir string
+
+	// Snapshot retention (optional — nil disables cleanup).
+	snapCleaner       SnapshotCleaner
+	snapMaxPerService int
+	snapMaxAge        time.Duration
 }
 
 // minResourceAge is the minimum time a resource must exist before GC considers
@@ -34,6 +45,15 @@ func New(db *sql.DB, dockerClient docker.Client, interval time.Duration, buildDi
 		interval: interval,
 		buildDir: buildDir,
 	}
+}
+
+// SetSnapshotCleaner configures snapshot retention cleanup. When set, the GC
+// loop will periodically remove snapshots exceeding the per-service count or
+// age limits.
+func (g *GC) SetSnapshotCleaner(cleaner SnapshotCleaner, maxPerService int, maxAge time.Duration) {
+	g.snapCleaner = cleaner
+	g.snapMaxPerService = maxPerService
+	g.snapMaxAge = maxAge
 }
 
 // Run starts the GC loop. Blocks until ctx is cancelled.
@@ -123,6 +143,17 @@ func (g *GC) collectOnce(ctx context.Context) error {
 	} else if pruned > 0 {
 		log.Printf("gc: pruned %d dangling images", pruned)
 		removed += pruned
+	}
+
+	// 5. Snapshot retention — clean expired snapshots by count and age.
+	if g.snapCleaner != nil {
+		snapRemoved, snapErr := g.snapCleaner.CleanExpired(ctx, g.snapMaxPerService, g.snapMaxAge)
+		if snapErr != nil {
+			log.Printf("gc: snapshot retention cleanup failed: %v", snapErr)
+		} else if snapRemoved > 0 {
+			log.Printf("gc: removed %d expired snapshots", snapRemoved)
+			removed += snapRemoved
+		}
 	}
 
 	if removed > 0 {

--- a/internal/gc/gc_test.go
+++ b/internal/gc/gc_test.go
@@ -161,6 +161,52 @@ func TestCollectOnce_PrunesDanglingImages(t *testing.T) {
 	assert.Equal(t, 1, mock.PruneDanglingImagesCalls)
 }
 
+// mockSnapshotCleaner implements SnapshotCleaner for testing.
+type mockSnapshotCleaner struct {
+	called          bool
+	maxPerService   int
+	maxAge          time.Duration
+	returnRemoved   int
+	returnErr       error
+}
+
+func (m *mockSnapshotCleaner) CleanExpired(ctx context.Context, maxPerService int, maxAge time.Duration) (int, error) {
+	m.called = true
+	m.maxPerService = maxPerService
+	m.maxAge = maxAge
+	return m.returnRemoved, m.returnErr
+}
+
+func TestCollectOnce_CallsSnapshotCleaner(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	mock := &testutil.MockDockerClient{}
+
+	cleaner := &mockSnapshotCleaner{returnRemoved: 5}
+	maxAge := 30 * 24 * time.Hour
+
+	g := New(stateDB, mock, 5*time.Minute, t.TempDir())
+	g.SetSnapshotCleaner(cleaner, 10, maxAge)
+
+	err := g.collectOnce(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, cleaner.called, "snapshot cleaner should have been called")
+	assert.Equal(t, 10, cleaner.maxPerService)
+	assert.Equal(t, maxAge, cleaner.maxAge)
+}
+
+func TestCollectOnce_SkipsSnapshotCleanerWhenNil(t *testing.T) {
+	stateDB := testutil.NewStateDB(t)
+	mock := &testutil.MockDockerClient{}
+
+	g := New(stateDB, mock, 5*time.Minute, t.TempDir())
+	// Don't set any snapshot cleaner
+
+	err := g.collectOnce(context.Background())
+	require.NoError(t, err)
+	// Should not panic or fail — just skip snapshot cleanup
+}
+
 func seedService(t *testing.T, stateDB *sql.DB, svcID, tenantID, containerID string) {
 	t.Helper()
 	_, err := stateDB.Exec(

--- a/internal/snapshots/snapshots.go
+++ b/internal/snapshots/snapshots.go
@@ -311,6 +311,169 @@ func (m *Manager) RestoreEnvVars(ctx context.Context, tenantID, snapshotID strin
 	return plaintext, nil
 }
 
+// CleanExpired removes snapshots that exceed per-service count or age limits.
+// It deletes the oldest snapshots first when over the count limit and removes
+// any snapshot older than maxAge. Returns the number of snapshots removed.
+func (m *Manager) CleanExpired(ctx context.Context, maxPerService int, maxAge time.Duration) (int, error) {
+	var removed int
+
+	// 1. Enforce per-service count limit (delete oldest when over limit).
+	if maxPerService > 0 {
+		n, err := m.cleanByCount(ctx, maxPerService)
+		if err != nil {
+			return removed, fmt.Errorf("clean by count: %w", err)
+		}
+		removed += n
+	}
+
+	// 2. Enforce age limit (delete snapshots older than maxAge).
+	if maxAge > 0 {
+		n, err := m.cleanByAge(ctx, maxAge)
+		if err != nil {
+			return removed, fmt.Errorf("clean by age: %w", err)
+		}
+		removed += n
+	}
+
+	return removed, nil
+}
+
+// cleanByCount finds services with more than maxPerService snapshots and
+// deletes the oldest ones exceeding the limit.
+func (m *Manager) cleanByCount(ctx context.Context, maxPerService int) (int, error) {
+	// Find services that exceed the snapshot count limit.
+	rows, err := m.db.QueryContext(ctx,
+		`SELECT service_id, COUNT(*) as cnt FROM snapshots GROUP BY service_id HAVING cnt > ?`,
+		maxPerService,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("query over-limit services: %w", err)
+	}
+	defer rows.Close()
+
+	type overLimit struct {
+		serviceID string
+		count     int
+	}
+	var services []overLimit
+	for rows.Next() {
+		var ol overLimit
+		if err := rows.Scan(&ol.serviceID, &ol.count); err != nil {
+			return 0, fmt.Errorf("scan over-limit row: %w", err)
+		}
+		services = append(services, ol)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate over-limit rows: %w", err)
+	}
+
+	var removed int
+	for _, svc := range services {
+		excess := svc.count - maxPerService
+		// Select the oldest snapshots beyond the limit.
+		snapRows, err := m.db.QueryContext(ctx,
+			`SELECT id, tenant_id, image_ref FROM snapshots
+			 WHERE service_id = ?
+			 ORDER BY created_at ASC
+			 LIMIT ?`,
+			svc.serviceID, excess,
+		)
+		if err != nil {
+			log.Printf("gc/snapshots: failed to query excess snapshots for service %s: %v", svc.serviceID, err)
+			continue
+		}
+
+		type snapInfo struct {
+			id       string
+			tenantID string
+			imageRef string
+		}
+		var toDelete []snapInfo
+		for snapRows.Next() {
+			var s snapInfo
+			if err := snapRows.Scan(&s.id, &s.tenantID, &s.imageRef); err != nil {
+				log.Printf("gc/snapshots: failed to scan snapshot row: %v", err)
+				continue
+			}
+			toDelete = append(toDelete, s)
+		}
+		snapRows.Close()
+
+		for _, s := range toDelete {
+			if err := m.deleteSnapshot(ctx, s.id, s.tenantID, s.imageRef); err != nil {
+				log.Printf("gc/snapshots: failed to delete snapshot %s: %v", s.id, err)
+				continue
+			}
+			removed++
+		}
+	}
+
+	return removed, nil
+}
+
+// cleanByAge deletes all snapshots older than maxAge.
+func (m *Manager) cleanByAge(ctx context.Context, maxAge time.Duration) (int, error) {
+	cutoff := time.Now().Add(-maxAge).Unix()
+
+	rows, err := m.db.QueryContext(ctx,
+		`SELECT id, tenant_id, image_ref FROM snapshots WHERE created_at < ?`,
+		cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("query expired snapshots: %w", err)
+	}
+	defer rows.Close()
+
+	type snapInfo struct {
+		id       string
+		tenantID string
+		imageRef string
+	}
+	var toDelete []snapInfo
+	for rows.Next() {
+		var s snapInfo
+		if err := rows.Scan(&s.id, &s.tenantID, &s.imageRef); err != nil {
+			log.Printf("gc/snapshots: failed to scan expired snapshot: %v", err)
+			continue
+		}
+		toDelete = append(toDelete, s)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate expired rows: %w", err)
+	}
+
+	var removed int
+	for _, s := range toDelete {
+		if err := m.deleteSnapshot(ctx, s.id, s.tenantID, s.imageRef); err != nil {
+			log.Printf("gc/snapshots: failed to delete expired snapshot %s: %v", s.id, err)
+			continue
+		}
+		removed++
+	}
+
+	return removed, nil
+}
+
+// deleteSnapshot removes a snapshot's Docker image and DB row.
+func (m *Manager) deleteSnapshot(ctx context.Context, id, tenantID, imageRef string) error {
+	// Best-effort image removal.
+	if imageRef != "" {
+		if err := m.docker.RemoveImage(ctx, imageRef); err != nil {
+			log.Printf("gc/snapshots: WARNING: failed to remove image %s: %v", imageRef, err)
+		}
+	}
+
+	_, err := m.db.ExecContext(ctx,
+		`DELETE FROM snapshots WHERE id = ? AND tenant_id = ?`,
+		id, tenantID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete snapshot row %s: %w", id, err)
+	}
+
+	return nil
+}
+
 func generateID() (string, error) {
 	b := make([]byte, 16)
 	if _, err := cryptoRand.Read(b); err != nil {

--- a/internal/snapshots/snapshots_test.go
+++ b/internal/snapshots/snapshots_test.go
@@ -393,3 +393,195 @@ func TestSnapshotRestoreEnvVars_Empty(t *testing.T) {
 	assert.NotNil(t, restored)
 	assert.Empty(t, restored)
 }
+
+// --- Snapshot retention tests ---
+
+// insertSnapshotWithAge directly inserts a snapshot with a specific created_at time
+// to avoid slow time.Sleep calls in tests.
+func insertSnapshotWithAge(t *testing.T, db *sql.DB, id, tenantID, serviceID string, createdAt int64) {
+	t.Helper()
+	imageRef := "127.0.0.1:5000/snapshots/" + tenantID + ":" + id
+	_, err := db.Exec(
+		`INSERT INTO snapshots (id, tenant_id, service_id, name, description, image_ref, env_encrypted, resource_config, port, created_at)
+		 VALUES (?, ?, ?, ?, '', ?, '', '{}', 8080, ?)`,
+		id, tenantID, serviceID, "snap-"+id, imageRef, createdAt,
+	)
+	require.NoError(t, err)
+}
+
+func TestCleanExpired_CountLimit_DeletesOldest(t *testing.T) {
+	mgr, mock, db, tenantID, serviceID := setupTestWithDB(t)
+	ctx := context.Background()
+
+	now := time.Now().Unix()
+	// Insert 5 snapshots with sequential timestamps (oldest first).
+	insertSnapshotWithAge(t, db, "snap-1", tenantID, serviceID, now-500)
+	insertSnapshotWithAge(t, db, "snap-2", tenantID, serviceID, now-400)
+	insertSnapshotWithAge(t, db, "snap-3", tenantID, serviceID, now-300)
+	insertSnapshotWithAge(t, db, "snap-4", tenantID, serviceID, now-200)
+	insertSnapshotWithAge(t, db, "snap-5", tenantID, serviceID, now-100)
+
+	// Set max 3 per service, no age limit.
+	removed, err := mgr.CleanExpired(ctx, 3, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed, "should delete 2 oldest snapshots")
+
+	// Verify the 2 oldest are gone and the 3 newest remain.
+	_, err = mgr.Get(ctx, tenantID, "snap-1")
+	assert.True(t, errors.Is(err, apierr.ErrNotFound), "snap-1 should be deleted")
+	_, err = mgr.Get(ctx, tenantID, "snap-2")
+	assert.True(t, errors.Is(err, apierr.ErrNotFound), "snap-2 should be deleted")
+
+	// The 3 newest should still exist.
+	_, err = mgr.Get(ctx, tenantID, "snap-3")
+	assert.NoError(t, err, "snap-3 should remain")
+	_, err = mgr.Get(ctx, tenantID, "snap-4")
+	assert.NoError(t, err, "snap-4 should remain")
+	_, err = mgr.Get(ctx, tenantID, "snap-5")
+	assert.NoError(t, err, "snap-5 should remain")
+
+	// Verify Docker images were cleaned up for the deleted snapshots.
+	assert.Len(t, mock.RemoveImageCalls, 2)
+}
+
+func TestCleanExpired_AgeLimit_DeletesExpired(t *testing.T) {
+	mgr, mock, db, tenantID, serviceID := setupTestWithDB(t)
+	ctx := context.Background()
+
+	now := time.Now().Unix()
+	oneDay := int64(24 * 60 * 60)
+
+	// Insert 3 snapshots: 2 old (40 days ago, 35 days ago) and 1 recent (5 days ago).
+	insertSnapshotWithAge(t, db, "old-1", tenantID, serviceID, now-40*oneDay)
+	insertSnapshotWithAge(t, db, "old-2", tenantID, serviceID, now-35*oneDay)
+	insertSnapshotWithAge(t, db, "recent-1", tenantID, serviceID, now-5*oneDay)
+
+	// Set max age to 30 days, no count limit.
+	maxAge := 30 * 24 * time.Hour
+	removed, err := mgr.CleanExpired(ctx, 0, maxAge)
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed, "should delete 2 expired snapshots")
+
+	// Old snapshots should be gone.
+	_, err = mgr.Get(ctx, tenantID, "old-1")
+	assert.True(t, errors.Is(err, apierr.ErrNotFound), "old-1 should be deleted")
+	_, err = mgr.Get(ctx, tenantID, "old-2")
+	assert.True(t, errors.Is(err, apierr.ErrNotFound), "old-2 should be deleted")
+
+	// Recent snapshot should remain.
+	_, err = mgr.Get(ctx, tenantID, "recent-1")
+	assert.NoError(t, err, "recent-1 should remain")
+
+	// Verify Docker images were cleaned up.
+	assert.Len(t, mock.RemoveImageCalls, 2)
+}
+
+func TestCleanExpired_WithinBothLimits_NothingDeleted(t *testing.T) {
+	mgr, mock, db, tenantID, serviceID := setupTestWithDB(t)
+	ctx := context.Background()
+
+	now := time.Now().Unix()
+	oneDay := int64(24 * 60 * 60)
+
+	// Insert 3 snapshots, all within limits (recent, under count).
+	insertSnapshotWithAge(t, db, "ok-1", tenantID, serviceID, now-2*oneDay)
+	insertSnapshotWithAge(t, db, "ok-2", tenantID, serviceID, now-1*oneDay)
+	insertSnapshotWithAge(t, db, "ok-3", tenantID, serviceID, now)
+
+	// Max 10 per service, max age 30 days — all should be safe.
+	removed, err := mgr.CleanExpired(ctx, 10, 30*24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed, "nothing should be deleted")
+
+	// All snapshots should still exist.
+	_, err = mgr.Get(ctx, tenantID, "ok-1")
+	assert.NoError(t, err)
+	_, err = mgr.Get(ctx, tenantID, "ok-2")
+	assert.NoError(t, err)
+	_, err = mgr.Get(ctx, tenantID, "ok-3")
+	assert.NoError(t, err)
+
+	// No image removal calls.
+	assert.Empty(t, mock.RemoveImageCalls)
+}
+
+func TestCleanExpired_MultipleServices(t *testing.T) {
+	mgr, _, db, tenantID, serviceID := setupTestWithDB(t)
+	ctx := context.Background()
+
+	// Create a second service.
+	svc2ID := "svc-2"
+	_, err := db.Exec(
+		`INSERT INTO services (id, tenant_id, name, status, image, port, created_at, updated_at) VALUES (?, ?, ?, 'running', 'nginx:latest', 8080, ?, ?)`,
+		svc2ID, tenantID, "test-svc-2", time.Now().Unix(), time.Now().Unix(),
+	)
+	require.NoError(t, err)
+
+	now := time.Now().Unix()
+	// Service 1: 4 snapshots (over limit of 2).
+	insertSnapshotWithAge(t, db, "s1-snap-1", tenantID, serviceID, now-400)
+	insertSnapshotWithAge(t, db, "s1-snap-2", tenantID, serviceID, now-300)
+	insertSnapshotWithAge(t, db, "s1-snap-3", tenantID, serviceID, now-200)
+	insertSnapshotWithAge(t, db, "s1-snap-4", tenantID, serviceID, now-100)
+
+	// Service 2: 2 snapshots (at limit of 2).
+	insertSnapshotWithAge(t, db, "s2-snap-1", tenantID, svc2ID, now-200)
+	insertSnapshotWithAge(t, db, "s2-snap-2", tenantID, svc2ID, now-100)
+
+	// Max 2 per service — should only trim service 1.
+	removed, err := mgr.CleanExpired(ctx, 2, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed, "should delete 2 oldest from service 1")
+
+	// Service 1: oldest 2 gone, newest 2 remain.
+	_, err = mgr.Get(ctx, tenantID, "s1-snap-1")
+	assert.True(t, errors.Is(err, apierr.ErrNotFound))
+	_, err = mgr.Get(ctx, tenantID, "s1-snap-2")
+	assert.True(t, errors.Is(err, apierr.ErrNotFound))
+	_, err = mgr.Get(ctx, tenantID, "s1-snap-3")
+	assert.NoError(t, err)
+	_, err = mgr.Get(ctx, tenantID, "s1-snap-4")
+	assert.NoError(t, err)
+
+	// Service 2: both remain.
+	_, err = mgr.Get(ctx, tenantID, "s2-snap-1")
+	assert.NoError(t, err)
+	_, err = mgr.Get(ctx, tenantID, "s2-snap-2")
+	assert.NoError(t, err)
+}
+
+func TestCleanExpired_BothLimitsApplied(t *testing.T) {
+	mgr, _, db, tenantID, serviceID := setupTestWithDB(t)
+	ctx := context.Background()
+
+	now := time.Now().Unix()
+	oneDay := int64(24 * 60 * 60)
+
+	// Insert 5 snapshots: 2 old (beyond age limit), 3 recent but over count.
+	insertSnapshotWithAge(t, db, "ancient-1", tenantID, serviceID, now-60*oneDay)
+	insertSnapshotWithAge(t, db, "ancient-2", tenantID, serviceID, now-45*oneDay)
+	insertSnapshotWithAge(t, db, "recent-1", tenantID, serviceID, now-3*oneDay)
+	insertSnapshotWithAge(t, db, "recent-2", tenantID, serviceID, now-2*oneDay)
+	insertSnapshotWithAge(t, db, "recent-3", tenantID, serviceID, now-1*oneDay)
+
+	// Max 3 per service AND max 30 days.
+	// Count pass runs first: 5 snapshots > 3, deletes 2 oldest (ancient-1, ancient-2).
+	// Age pass runs second: remaining 3 are all within 30 days, nothing more to delete.
+	removed, err := mgr.CleanExpired(ctx, 3, 30*24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed)
+
+	// Ancient ones are gone.
+	_, err = mgr.Get(ctx, tenantID, "ancient-1")
+	assert.True(t, errors.Is(err, apierr.ErrNotFound))
+	_, err = mgr.Get(ctx, tenantID, "ancient-2")
+	assert.True(t, errors.Is(err, apierr.ErrNotFound))
+
+	// Recent ones remain.
+	_, err = mgr.Get(ctx, tenantID, "recent-1")
+	assert.NoError(t, err)
+	_, err = mgr.Get(ctx, tenantID, "recent-2")
+	assert.NoError(t, err)
+	_, err = mgr.Get(ctx, tenantID, "recent-3")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- Adds automatic snapshot cleanup to GC loop (runs every 5 min)
- Per-service count limit (default 10) — deletes oldest first
- Age limit (default 30 days) — deletes expired snapshots
- Configurable via AH_SNAPSHOT_MAX_PER_SERVICE and AH_SNAPSHOT_MAX_AGE env vars
- Cleans up Docker images when snapshots are deleted
- 7 new tests

## Test plan
- [x] Count limit deletes oldest snapshots
- [x] Age limit deletes expired snapshots
- [x] Within-limits preserves all snapshots
- [x] Multiple services handled independently
- [x] Both limits applied together
- [x] GC integration tests
- [x] `go test ./...` passes
Closes #103
🤖 Generated with [Claude Code](https://claude.com/claude-code)