### PR TITLE
feat(#85): graceful bootstrap token rotation

### DIFF
--- a/cmd/ah/main.go
+++ b/cmd/ah/main.go
@@ -65,9 +65,13 @@ func main() {
 		}
 	}
 
-	// Bootstrap token is always required unless --dev + --open-registration
-	bootstrapToken := strings.TrimSpace(os.Getenv("AH_BOOTSTRAP_TOKEN"))
-	if bootstrapToken == "" {
+	// Bootstrap token is always required unless --dev + --open-registration.
+	// Supports comma-separated list for graceful rotation:
+	//   AH_BOOTSTRAP_TOKEN=new_token,old_token
+	// All listed tokens are valid for registration and recovery.
+	bootstrapTokenRaw := strings.TrimSpace(os.Getenv("AH_BOOTSTRAP_TOKEN"))
+	var bootstrapTokens []string
+	if bootstrapTokenRaw == "" {
 		if !*devMode {
 			log.Fatalf("AH_BOOTSTRAP_TOKEN must be set (or use --dev --open-registration)")
 		}
@@ -75,8 +79,23 @@ func main() {
 			log.Fatalf("AH_BOOTSTRAP_TOKEN must be set. Use --open-registration with --dev to allow open registration.")
 		}
 		log.Printf("WARNING: open registration enabled — anyone can create tenants")
-	} else if len(bootstrapToken) < 32 {
-		log.Fatalf("AH_BOOTSTRAP_TOKEN must be at least 32 characters for brute-force resistance (got %d)", len(bootstrapToken))
+	} else {
+		for _, tok := range strings.Split(bootstrapTokenRaw, ",") {
+			tok = strings.TrimSpace(tok)
+			if tok == "" {
+				continue
+			}
+			if len(tok) < 32 {
+				log.Fatalf("each bootstrap token must be at least 32 characters for brute-force resistance (got %d for token starting with %.8s...)", len(tok), tok)
+			}
+			bootstrapTokens = append(bootstrapTokens, tok)
+		}
+		if len(bootstrapTokens) == 0 {
+			log.Fatalf("AH_BOOTSTRAP_TOKEN is set but contains no valid tokens")
+		}
+		if len(bootstrapTokens) > 1 {
+			log.Printf("bootstrap token rotation: %d tokens configured (all are valid for registration and recovery)", len(bootstrapTokens))
+		}
 	}
 
 	if *openRegistration && !*devMode {
@@ -161,7 +180,7 @@ func main() {
 		Store:            store,
 		MasterKey:        masterKey[:32],
 		DevMode:          *devMode,
-		BootstrapToken:   bootstrapToken,
+		BootstrapTokens:  bootstrapTokens,
 		OpenRegistration: *openRegistration,
 		Docker:           dockerClient,
 		BuildManager:     buildMgr,

--- a/internal/api/bootstrap.go
+++ b/internal/api/bootstrap.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// BootstrapTokenValidateRequest is the body for POST /v1/system/bootstrap-token/validate.
+type BootstrapTokenValidateRequest struct {
+	Token string `json:"token"`
+}
+
+// BootstrapTokenValidateResponse indicates whether the provided token is valid.
+type BootstrapTokenValidateResponse struct {
+	Valid bool `json:"valid"`
+}
+
+// handleBootstrapTokenValidate handles POST /v1/system/bootstrap-token/validate.
+//
+// This endpoint allows operators to verify that a bootstrap token is accepted
+// by the server, which is useful during token rotation to confirm that both
+// the old and new tokens work before removing the old one.
+//
+// Security model:
+//   - Rate-limited by the same per-IP / global limiter used for tenant
+//     registration (5/IP/hour, 20/global/hour) to prevent brute-force.
+//   - Returns a simple boolean; does not distinguish between "no tokens
+//     configured" and "token not matched" to avoid information leakage.
+func (s *Server) handleBootstrapTokenValidate(w http.ResponseWriter, r *http.Request) {
+	// Apply the same rate limiter as tenant registration.
+	ip := trustedRealIP(r)
+	if ok, wait := regLimiter.allow(ip); !ok {
+		secs := int(math.Ceil(wait.Seconds()))
+		if secs < 1 {
+			secs = 1
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
+		writeError(w, http.StatusTooManyRequests, "rate limit exceeded, try again later")
+		return
+	}
+
+	var req BootstrapTokenValidateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeDecodeError(w, err)
+		return
+	}
+
+	provided := strings.TrimSpace(req.Token)
+	valid := len(s.bootstrapTokens) > 0 && validateBootstrapToken(provided, s.bootstrapTokens, s.masterKey)
+
+	writeJSON(w, http.StatusOK, BootstrapTokenValidateResponse{Valid: valid})
+}

--- a/internal/api/bootstrap_test.go
+++ b/internal/api/bootstrap_test.go
@@ -1,0 +1,404 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dennisonbertram/agentic-hosting/internal/db"
+	"github.com/dennisonbertram/agentic-hosting/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tokenRequest builds a POST /v1/system/bootstrap-token/validate request with
+// a per-test source IP to avoid sharing rate-limit buckets across tests.
+func tokenRequest(ip string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/system/bootstrap-token/validate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("X-Real-Ip", ip)
+	return req
+}
+
+// registerRequest builds a POST /v1/tenants/register request with a per-test
+// source IP and the given bootstrap token header.
+func registerRequest(ip, bootstrapToken string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/tenants/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("X-Real-Ip", ip)
+	if bootstrapToken != "" {
+		req.Header.Set("X-Bootstrap-Token", bootstrapToken)
+	}
+	return req
+}
+
+func TestValidateBootstrapToken(t *testing.T) {
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+	t.Run("single token matches", func(t *testing.T) {
+		assert.True(t, validateBootstrapToken("my-token", []string{"my-token"}, masterKey))
+	})
+
+	t.Run("single token does not match", func(t *testing.T) {
+		assert.False(t, validateBootstrapToken("wrong-token", []string{"my-token"}, masterKey))
+	})
+
+	t.Run("multiple tokens first matches", func(t *testing.T) {
+		tokens := []string{"token-a", "token-b", "token-c"}
+		assert.True(t, validateBootstrapToken("token-a", tokens, masterKey))
+	})
+
+	t.Run("multiple tokens last matches", func(t *testing.T) {
+		tokens := []string{"token-a", "token-b", "token-c"}
+		assert.True(t, validateBootstrapToken("token-c", tokens, masterKey))
+	})
+
+	t.Run("multiple tokens middle matches", func(t *testing.T) {
+		tokens := []string{"token-a", "token-b", "token-c"}
+		assert.True(t, validateBootstrapToken("token-b", tokens, masterKey))
+	})
+
+	t.Run("multiple tokens none match", func(t *testing.T) {
+		tokens := []string{"token-a", "token-b", "token-c"}
+		assert.False(t, validateBootstrapToken("token-d", tokens, masterKey))
+	})
+
+	t.Run("empty token list rejects everything", func(t *testing.T) {
+		assert.False(t, validateBootstrapToken("any-token", []string{}, masterKey))
+	})
+
+	t.Run("empty provided token", func(t *testing.T) {
+		assert.False(t, validateBootstrapToken("", []string{"token-a"}, masterKey))
+	})
+
+	t.Run("empty provided against empty list", func(t *testing.T) {
+		assert.False(t, validateBootstrapToken("", []string{}, masterKey))
+	})
+}
+
+func TestHandleBootstrapTokenValidate(t *testing.T) {
+	regLimiter.resetForTest()
+	const tokenA = "test-bootstrap-token-aaaaaaa-32chars"
+	const tokenB = "test-bootstrap-token-bbbbbbb-32chars"
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+	newServer := func(t *testing.T, tokens []string) *Server {
+		t.Helper()
+		stateDB := testutil.NewStateDB(t)
+		return NewServer(ServerConfig{
+			Store:           &db.Store{StateDB: stateDB},
+			MasterKey:       masterKey,
+			DevMode:         true,
+			BootstrapTokens: tokens,
+		})
+	}
+
+	t.Run("valid single token returns valid=true", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA})
+
+		body, _ := json.Marshal(BootstrapTokenValidateRequest{Token: tokenA})
+		req := tokenRequest("10.1.1.1", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		var resp BootstrapTokenValidateResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+		assert.True(t, resp.Valid)
+	})
+
+	t.Run("invalid token returns valid=false", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA})
+
+		body, _ := json.Marshal(BootstrapTokenValidateRequest{Token: "wrong-token"})
+		req := tokenRequest("10.1.1.2", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		var resp BootstrapTokenValidateResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+		assert.False(t, resp.Valid)
+	})
+
+	t.Run("both tokens valid during rotation", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA, tokenB})
+
+		// Token A should be valid
+		bodyA, _ := json.Marshal(BootstrapTokenValidateRequest{Token: tokenA})
+		reqA := tokenRequest("10.1.1.3", bodyA)
+		rrA := httptest.NewRecorder()
+		srv.ServeHTTP(rrA, reqA)
+
+		require.Equal(t, http.StatusOK, rrA.Code)
+		var respA BootstrapTokenValidateResponse
+		require.NoError(t, json.NewDecoder(rrA.Body).Decode(&respA))
+		assert.True(t, respA.Valid)
+
+		// Token B should also be valid
+		bodyB, _ := json.Marshal(BootstrapTokenValidateRequest{Token: tokenB})
+		reqB := tokenRequest("10.1.1.4", bodyB)
+		rrB := httptest.NewRecorder()
+		srv.ServeHTTP(rrB, reqB)
+
+		require.Equal(t, http.StatusOK, rrB.Code)
+		var respB BootstrapTokenValidateResponse
+		require.NoError(t, json.NewDecoder(rrB.Body).Decode(&respB))
+		assert.True(t, respB.Valid)
+	})
+
+	t.Run("no tokens configured returns valid=false", func(t *testing.T) {
+		srv := newServer(t, nil)
+
+		body, _ := json.Marshal(BootstrapTokenValidateRequest{Token: "any-token"})
+		req := tokenRequest("10.1.1.5", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		var resp BootstrapTokenValidateResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+		assert.False(t, resp.Valid)
+	})
+
+	t.Run("invalid request body returns 400", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA})
+
+		req := tokenRequest("10.1.1.6", []byte("not json"))
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+}
+
+func TestRegistrationWithMultipleBootstrapTokens(t *testing.T) {
+	regLimiter.resetForTest()
+	const tokenA = "test-bootstrap-token-aaaaaaa-32chars"
+	const tokenB = "test-bootstrap-token-bbbbbbb-32chars"
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+	newServer := func(t *testing.T, tokens []string) *Server {
+		t.Helper()
+		stateDB := testutil.NewStateDB(t)
+		return NewServer(ServerConfig{
+			Store:           &db.Store{StateDB: stateDB},
+			MasterKey:       masterKey,
+			DevMode:         true,
+			BootstrapTokens: tokens,
+		})
+	}
+
+	t.Run("registration with first token succeeds", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA, tokenB})
+
+		body, _ := json.Marshal(RegisterRequest{Name: "TenantA", Email: "a@example.com"})
+		req := registerRequest("10.2.1.1", tokenA, body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+	})
+
+	t.Run("registration with second token succeeds", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA, tokenB})
+
+		body, _ := json.Marshal(RegisterRequest{Name: "TenantB", Email: "b@example.com"})
+		req := registerRequest("10.2.1.2", tokenB, body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+	})
+
+	t.Run("registration with unknown token fails", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA, tokenB})
+
+		body, _ := json.Marshal(RegisterRequest{Name: "TenantC", Email: "c@example.com"})
+		req := registerRequest("10.2.1.3", "unknown-token", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("registration with no tokens configured returns 503", func(t *testing.T) {
+		srv := newServer(t, nil)
+
+		body, _ := json.Marshal(RegisterRequest{Name: "TenantD", Email: "d@example.com"})
+		req := registerRequest("10.2.1.4", tokenA, body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	})
+
+	t.Run("registration with single token still works (backward compatibility)", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA})
+
+		body, _ := json.Marshal(RegisterRequest{Name: "TenantE", Email: "e@example.com"})
+		req := registerRequest("10.2.1.5", tokenA, body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+	})
+}
+
+func TestRecoveryWithMultipleBootstrapTokens(t *testing.T) {
+	regLimiter.resetForTest()
+	const tokenA = "test-bootstrap-token-aaaaaaa-32chars"
+	const tokenB = "test-bootstrap-token-bbbbbbb-32chars"
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+	newServer := func(t *testing.T, tokens []string) *Server {
+		t.Helper()
+		stateDB := testutil.NewStateDB(t)
+		_, err := stateDB.Exec(
+			`INSERT INTO tenants (id, name, email, status, created_at, updated_at)
+			 VALUES (?, ?, ?, 'active', 1, 1)`,
+			"tenant-rot", "Rotation Tenant", "rotation@example.com",
+		)
+		require.NoError(t, err)
+		_, err = stateDB.Exec(`INSERT INTO tenant_quotas (tenant_id) VALUES (?)`, "tenant-rot")
+		require.NoError(t, err)
+
+		return NewServer(ServerConfig{
+			Store:           &db.Store{StateDB: stateDB},
+			MasterKey:       masterKey,
+			DevMode:         true,
+			BootstrapTokens: tokens,
+		})
+	}
+
+	t.Run("recovery with first token succeeds", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA, tokenB})
+
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "rotation@example.com",
+			BootstrapToken: tokenA,
+		})
+		req := recoverRequest("10.3.1.1", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+	})
+
+	t.Run("recovery with second token succeeds", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA, tokenB})
+
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "rotation@example.com",
+			BootstrapToken: tokenB,
+		})
+		req := recoverRequest("10.3.1.2", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+	})
+
+	t.Run("recovery with unknown token fails", func(t *testing.T) {
+		srv := newServer(t, []string{tokenA, tokenB})
+
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "rotation@example.com",
+			BootstrapToken: "wrong-token",
+		})
+		req := recoverRequest("10.3.1.3", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("recovery with no tokens configured returns 503", func(t *testing.T) {
+		srv := newServer(t, nil)
+
+		body, _ := json.Marshal(KeyRecoverRequest{
+			Email:          "rotation@example.com",
+			BootstrapToken: tokenA,
+		})
+		req := recoverRequest("10.3.1.4", body)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	})
+}
+
+func TestTokenRotationWorkflow(t *testing.T) {
+	regLimiter.resetForTest()
+	// Simulates the full rotation workflow:
+	// 1. Start with token A only
+	// 2. Register with token A (works)
+	// 3. Add token B alongside A (simulating deployment)
+	// 4. Register with token B (works)
+	// 5. Register with token A (still works)
+	// 6. Remove token A, keep only B (simulating second deployment)
+	// 7. Register with token A (fails)
+	// 8. Register with token B (works)
+	const tokenA = "rotation-test-token-aaaaaaa-32charslong"
+	const tokenB = "rotation-test-token-bbbbbbb-32charslong"
+	masterKey := []byte("0123456789abcdef0123456789abcdef")
+
+	// Phase 1: Only token A
+	stateDB := testutil.NewStateDB(t)
+	srv := NewServer(ServerConfig{
+		Store:           &db.Store{StateDB: stateDB},
+		MasterKey:       masterKey,
+		DevMode:         true,
+		BootstrapTokens: []string{tokenA},
+	})
+
+	body, _ := json.Marshal(RegisterRequest{Name: "Phase1", Email: "phase1@example.com"})
+	req := registerRequest("10.4.1.1", tokenA, body)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code, "Phase 1: token A should work")
+
+	// Phase 2: Both tokens A and B (rotation in progress)
+	srv2 := NewServer(ServerConfig{
+		Store:           &db.Store{StateDB: stateDB},
+		MasterKey:       masterKey,
+		DevMode:         true,
+		BootstrapTokens: []string{tokenB, tokenA}, // new token first
+	})
+
+	body2a, _ := json.Marshal(RegisterRequest{Name: "Phase2A", Email: "phase2a@example.com"})
+	req2a := registerRequest("10.4.1.2", tokenA, body2a)
+	rr2a := httptest.NewRecorder()
+	srv2.ServeHTTP(rr2a, req2a)
+	require.Equal(t, http.StatusCreated, rr2a.Code, "Phase 2: old token A should still work")
+
+	body2b, _ := json.Marshal(RegisterRequest{Name: "Phase2B", Email: "phase2b@example.com"})
+	req2b := registerRequest("10.4.1.3", tokenB, body2b)
+	rr2b := httptest.NewRecorder()
+	srv2.ServeHTTP(rr2b, req2b)
+	require.Equal(t, http.StatusCreated, rr2b.Code, "Phase 2: new token B should work")
+
+	// Phase 3: Only token B (rotation complete, old token removed)
+	srv3 := NewServer(ServerConfig{
+		Store:           &db.Store{StateDB: stateDB},
+		MasterKey:       masterKey,
+		DevMode:         true,
+		BootstrapTokens: []string{tokenB},
+	})
+
+	body3a, _ := json.Marshal(RegisterRequest{Name: "Phase3A", Email: "phase3a@example.com"})
+	req3a := registerRequest("10.4.1.4", tokenA, body3a)
+	rr3a := httptest.NewRecorder()
+	srv3.ServeHTTP(rr3a, req3a)
+	assert.Equal(t, http.StatusUnauthorized, rr3a.Code, "Phase 3: old token A should be rejected")
+
+	body3b, _ := json.Marshal(RegisterRequest{Name: "Phase3B", Email: "phase3b@example.com"})
+	req3b := registerRequest("10.4.1.5", tokenB, body3b)
+	rr3b := httptest.NewRecorder()
+	srv3.ServeHTTP(rr3b, req3b)
+	require.Equal(t, http.StatusCreated, rr3b.Code, "Phase 3: new token B should work")
+}

--- a/internal/api/recovery.go
+++ b/internal/api/recovery.go
@@ -53,8 +53,8 @@ func (s *Server) handleKeyRecover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fail closed: reject if bootstrap token is not configured.
-	if s.bootstrapToken == "" {
+	// Fail closed: reject if no bootstrap tokens are configured.
+	if len(s.bootstrapTokens) == 0 {
 		writeError(w, http.StatusServiceUnavailable, "recovery temporarily unavailable")
 		return
 	}
@@ -65,9 +65,9 @@ func (s *Server) handleKeyRecover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// HMAC-compare the provided token to prevent length-leak attacks.
+	// HMAC-compare against all configured tokens to support graceful rotation.
 	provided := strings.TrimSpace(req.BootstrapToken)
-	if !hmacEqual(provided, s.bootstrapToken, s.masterKey) {
+	if !validateBootstrapToken(provided, s.bootstrapTokens, s.masterKey) {
 		writeError(w, http.StatusUnauthorized, "invalid bootstrap token or email")
 		return
 	}

--- a/internal/api/recovery_test.go
+++ b/internal/api/recovery_test.go
@@ -29,6 +29,7 @@ func recoverRequest(ip string, body []byte) *http.Request {
 }
 
 func TestHandleKeyRecover(t *testing.T) {
+	regLimiter.resetForTest()
 	const bootstrapToken = "test-bootstrap-token-for-recovery"
 	masterKey := []byte("0123456789abcdef0123456789abcdef")
 
@@ -47,10 +48,10 @@ func TestHandleKeyRecover(t *testing.T) {
 		require.NoError(t, err)
 
 		return NewServer(ServerConfig{
-			Store:          &db.Store{StateDB: stateDB},
-			MasterKey:      masterKey,
-			DevMode:        true,
-			BootstrapToken: bootstrapToken,
+			Store:           &db.Store{StateDB: stateDB},
+			MasterKey:       masterKey,
+			DevMode:         true,
+			BootstrapTokens: []string{bootstrapToken},
 		})
 	}
 
@@ -132,10 +133,10 @@ func TestHandleKeyRecover(t *testing.T) {
 		require.NoError(t, err)
 
 		srv := NewServer(ServerConfig{
-			Store:          &db.Store{StateDB: stateDB},
-			MasterKey:      masterKey,
-			DevMode:        true,
-			BootstrapToken: bootstrapToken,
+			Store:           &db.Store{StateDB: stateDB},
+			MasterKey:       masterKey,
+			DevMode:         true,
+			BootstrapTokens: []string{bootstrapToken},
 		})
 
 		body, _ := json.Marshal(KeyRecoverRequest{

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -27,7 +27,7 @@ type ServerConfig struct {
 	Store            *db.Store
 	MasterKey        []byte
 	DevMode          bool
-	BootstrapToken   string
+	BootstrapTokens  []string
 	OpenRegistration bool
 	Docker           docker.Client
 	BuildManager     *builds.Manager
@@ -59,7 +59,7 @@ type Server struct {
 	store             *db.Store
 	masterKey         []byte
 	devMode           bool
-	bootstrapToken    string
+	bootstrapTokens   []string
 	openRegistration  bool
 	baseDomain        string
 	router            chi.Router
@@ -97,7 +97,7 @@ func NewServer(cfg ServerConfig) *Server {
 		store:             cfg.Store,
 		masterKey:         cfg.MasterKey,
 		devMode:           cfg.DevMode,
-		bootstrapToken:    cfg.BootstrapToken,
+		bootstrapTokens:   cfg.BootstrapTokens,
 		openRegistration:  cfg.OpenRegistration,
 		baseDomain:        cfg.BaseDomain,
 		authInvalidator:   authInvalidator,
@@ -146,6 +146,9 @@ func (s *Server) setupRoutes() {
 		// Recovery endpoint: authenticated by bootstrap token, not an API key.
 		// Allows tenants who have lost all their keys to obtain a new one.
 		r.Post("/v1/auth/recover", s.handleKeyRecover)
+		// Validate endpoint: checks if a bootstrap token is valid.
+		// Useful during token rotation to verify both old and new tokens.
+		r.Post("/v1/system/bootstrap-token/validate", s.handleBootstrapTokenValidate)
 	})
 
 	// Authenticated short-lived routes keep the standard request timeout.

--- a/internal/api/tenants.go
+++ b/internal/api/tenants.go
@@ -86,6 +86,16 @@ var regLimiter = &registrationLimiter{
 	// globalWindowAt zero-value: first request starts the window
 }
 
+// resetForTest resets the rate limiter state. Exported only for tests within
+// the api package (unexported, same-package access only).
+func (rl *registrationLimiter) resetForTest() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.globalCount = 0
+	rl.globalWindowAt = time.Time{}
+	rl.entries = cache.New[string, *regEntry](regMaxEntries)
+}
+
 func init() {
 	go func() {
 		ticker := time.NewTicker(5 * time.Minute)
@@ -151,17 +161,17 @@ func (s *Server) handleTenantRegister(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Bootstrap token gate — open registration (--dev --open-registration) is
-	// the only path that skips this. Without that explicit flag, bootstrapToken
+	// the only path that skips this. Without that explicit flag, bootstrapTokens
 	// is always required (main.go fatals if unset outside dev+open-registration).
 	if !s.openRegistration {
-		// Fail closed: reject if bootstrap token is not configured
-		if s.bootstrapToken == "" {
+		// Fail closed: reject if no bootstrap tokens are configured
+		if len(s.bootstrapTokens) == 0 {
 			writeError(w, http.StatusServiceUnavailable, "registration temporarily unavailable")
 			return
 		}
 		provided := strings.TrimSpace(r.Header.Get("X-Bootstrap-Token"))
-		// HMAC-compare to prevent length-leak from ConstantTimeCompare
-		if !hmacEqual(provided, s.bootstrapToken, s.masterKey) {
+		// HMAC-compare against all configured tokens to support graceful rotation.
+		if !validateBootstrapToken(provided, s.bootstrapTokens, s.masterKey) {
 			writeError(w, http.StatusUnauthorized, "missing or invalid bootstrap token")
 			return
 		}
@@ -422,4 +432,22 @@ func hmacEqual(a, b string, key []byte) bool {
 	macB := hmac.New(sha256.New, key)
 	macB.Write([]byte(b))
 	return hmac.Equal(macA.Sum(nil), macB.Sum(nil))
+}
+
+// validateBootstrapToken checks whether the provided token matches any of the
+// configured bootstrap tokens. All comparisons use HMAC-compare to prevent
+// timing side-channels. This supports graceful token rotation: operators can
+// set AH_BOOTSTRAP_TOKEN=new,old, deploy, then remove the old token.
+//
+// Important: this function always iterates over ALL tokens regardless of whether
+// an early match is found. This prevents leaking which position in the list
+// matched (or whether a match occurred at all) via timing analysis.
+func validateBootstrapToken(provided string, tokens []string, masterKey []byte) bool {
+	matched := false
+	for _, tok := range tokens {
+		if hmacEqual(provided, tok, masterKey) {
+			matched = true
+		}
+	}
+	return matched
 }


### PR DESCRIPTION
## Summary
- Supports comma-separated bootstrap tokens in AH_BOOTSTRAP_TOKEN for zero-downtime rotation
- All listed tokens accepted for registration and recovery
- Constant-time HMAC comparison iterates all tokens to prevent timing side-channels
- Adds POST /v1/system/bootstrap-token/validate endpoint for operator verification
- 20 tests covering unit, integration, and full rotation workflow

## Test plan
- [x] Single token (unchanged behavior)
- [x] Multiple tokens (both accepted)
- [x] Invalid token rejected
- [x] Validate endpoint returns correct status
- [x] Full rotation workflow: register with A, add B, register with B, remove A
- [x] `go test ./...` passes
Closes #85
🤖 Generated with [Claude Code](https://claude.com/claude-code)